### PR TITLE
fix: LoginForm を Chakra UI ベースに作り直す

### DIFF
--- a/src/components/Auth/LoginForm.tsx
+++ b/src/components/Auth/LoginForm.tsx
@@ -1,5 +1,11 @@
 import { useState } from 'react'
+import {
+  Box, VStack, Divider, Text, HStack, Flex
+} from '@chakra-ui/react'
 import { useAuth } from '../../hooks/useAuth'
+import { Button } from '../ui/Button'
+import { Input } from '../ui/Input'
+import { Card } from '../ui/Card'
 
 export function LoginForm() {
   const { signInWithEmail, signUpWithEmail, signInWithGoogle } = useAuth()
@@ -7,43 +13,91 @@ export function LoginForm() {
   const [password, setPassword] = useState('')
   const [isSignUp, setIsSignUp] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     setError(null)
+    setIsLoading(true)
     const { error } = isSignUp
       ? await signUpWithEmail(email, password)
       : await signInWithEmail(email, password)
+    setIsLoading(false)
     if (error) setError(error.message)
   }
 
   return (
-    <div style={{ maxWidth: 400, margin: '80px auto', padding: 24 }}>
-      <h1>Daily Share</h1>
-      <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
-        <input
-          type="email"
-          placeholder="メールアドレス"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-          required
-        />
-        <input
-          type="password"
-          placeholder="パスワード"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-          required
-        />
-        {error && <p style={{ color: 'red', margin: 0 }}>{error}</p>}
-        <button type="submit">{isSignUp ? 'アカウント作成' : 'ログイン'}</button>
-        <button type="button" onClick={() => signInWithGoogle()}>
-          Google でログイン
-        </button>
-        <button type="button" onClick={() => setIsSignUp((v) => !v)}>
-          {isSignUp ? 'ログインに切り替え' : 'アカウント作成に切り替え'}
-        </button>
-      </form>
-    </div>
+    <Flex minH="100vh" align="center" justify="center" px={4}>
+      <Card w="full" maxW="400px">
+        <VStack spacing={6} align="stretch">
+          <Box>
+            <Text fontSize="2xl" fontWeight="medium" color="gray.900">
+              Daily Share
+            </Text>
+            <Text fontSize="sm" color="gray.500" mt={1}>
+              {isSignUp ? 'アカウントを作成してください' : 'アカウントにログインしてください'}
+            </Text>
+          </Box>
+
+          <VStack as="form" onSubmit={handleSubmit} spacing={4} align="stretch">
+            {error && (
+              <Box
+                bg="danger.50"
+                border="1px solid"
+                borderColor="danger.200"
+                borderRadius="md"
+                px={3}
+                py={2}
+              >
+                <Text fontSize="sm" color="danger.600">{error}</Text>
+              </Box>
+            )}
+            <Input
+              label="メールアドレス"
+              id="email"
+              type="email"
+              placeholder="example@email.com"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+            />
+            <Input
+              label="パスワード"
+              id="password"
+              type="password"
+              placeholder="パスワードを入力"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+            />
+            <Button type="submit" isLoading={isLoading} w="full">
+              {isSignUp ? 'アカウント作成' : 'ログイン'}
+            </Button>
+          </VStack>
+
+          <HStack>
+            <Divider />
+            <Text fontSize="xs" color="gray.400" whiteSpace="nowrap">または</Text>
+            <Divider />
+          </HStack>
+
+          <Button variant="secondary" w="full" onClick={() => signInWithGoogle()}>
+            Google でログイン
+          </Button>
+
+          <Text textAlign="center" fontSize="sm" color="gray.500">
+            {isSignUp ? 'すでにアカウントをお持ちですか？' : 'アカウントをお持ちでないですか？'}
+            {' '}
+            <Box
+              as="span"
+              color="primary.400"
+              cursor="pointer"
+              fontWeight="medium"
+              onClick={() => { setIsSignUp(v => !v); setError(null) }}
+            >
+              {isSignUp ? 'ログイン' : '新規登録'}
+            </Box>
+          </Text>
+        </VStack>
+      </Card>
+    </Flex>
   )
 }


### PR DESCRIPTION
## 概要

LoginForm をネイティブHTML から Chakra UI ベースに作り直す

Closes #2

## 変更内容
- ネイティブの `<input>` / `<button>` / `<div style=...>` を `Input` / `Button` / `Card` コンポーネントに統一
- `isLoading` state を追加し、submit中の二重送信を防止
- エラー表示をパスワード欄直下からフォーム上部の `danger` カラーボックスに変更
- `required` 属性を削除（Supabase のエラーハンドリングで代替）

## 確認方法

```bash
npm run dev
```

- ログイン・新規登録が正常に動作すること
- 誤ったメールアドレス／パスワードでエラーメッセージが表示されること
- submit中にボタンがローディング状態になること

## チェックリスト
- [x] `npm run lint` が通る
- [x] `npm run build` が通る
- [x] 動作確認済み
- [x] レビュアーを設定した