### PR TITLE
feat: SignupForm + ProfileSetupModal を実装 (#3)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,16 +1,58 @@
+import { useEffect, useState } from 'react'
 import { ChakraProvider } from '@chakra-ui/react'
 import theme from './theme/theme'
+import { supabase } from './lib/supabase'
 import { AuthGuard } from './components/AuthGuard'
 import { LoginForm } from './components/Auth/LoginForm'
+import { SignupForm } from './components/Auth/SignupForm'
+import { ProfileSetupModal } from './components/Auth/ProfileSetupModal'
 import { Map } from './components/Map/Map'
 import { useAuth } from './hooks/useAuth'
+import { LoadingSpinner } from './components/ui/LoadingSpinner'
+
+type AuthView = 'login' | 'signup'
 
 function Inner() {
   const { user, signOut } = useAuth()
+  const [authView, setAuthView] = useState<AuthView>('login')
+  const [profileChecked, setProfileChecked] = useState(false)
+  const [needsProfile, setNeedsProfile] = useState(false)
 
-  if (!user) return <LoginForm />
+  useEffect(() => {
+    if (!user) {
+      setProfileChecked(false)
+      setNeedsProfile(false)
+      return
+    }
+    supabase
+      .from('users')
+      .select('displayName')
+      .eq('id', user.id)
+      .single()
+      .then(({ data }) => {
+        setNeedsProfile(!data?.displayName)
+        setProfileChecked(true)
+      })
+  }, [user])
 
-  return <Map onSignOut={signOut} />
+  if (!user) {
+    if (authView === 'signup') {
+      return <SignupForm onSwitchToLogin={() => setAuthView('login')} />
+    }
+    return <LoginForm onSwitchToSignup={() => setAuthView('signup')} />
+  }
+
+  if (!profileChecked) return <LoadingSpinner />
+
+  return (
+    <>
+      <Map onSignOut={signOut} />
+      <ProfileSetupModal
+        isOpen={needsProfile}
+        onComplete={() => setNeedsProfile(false)}
+      />
+    </>
+  )
 }
 
 function App() {

--- a/src/components/Auth/ProfileSetupModal.tsx
+++ b/src/components/Auth/ProfileSetupModal.tsx
@@ -1,0 +1,146 @@
+import { useState } from 'react'
+import {
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  VStack,
+  Text,
+  Box,
+  SimpleGrid,
+} from '@chakra-ui/react'
+import { useAuth } from '../../hooks/useAuth'
+import { Button } from '../ui/Button'
+import { Input } from '../ui/Input'
+
+interface ProfileSetupModalProps {
+  isOpen: boolean
+  onComplete: () => void
+}
+
+export function ProfileSetupModal({ isOpen, onComplete }: ProfileSetupModalProps) {
+  const { user, updateProfile } = useAuth()
+  const [displayName, setDisplayName] = useState('')
+  const [familyName, setFamilyName] = useState('')
+  const [firstName, setFirstName] = useState('')
+  const [phoneNumber, setPhoneNumber] = useState('')
+  const [birthday, setBirthday] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!user) return
+    setError(null)
+    setIsLoading(true)
+    const { error } = await updateProfile(user.id, {
+      displayName,
+      familyName: familyName || null,
+      firstName: firstName || null,
+      phoneNumber: phoneNumber || null,
+      birthday: birthday || null,
+    })
+    setIsLoading(false)
+    if (error) {
+      setError(error.message)
+    } else {
+      onComplete()
+    }
+  }
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={() => {}}
+      closeOnOverlayClick={false}
+      closeOnEsc={false}
+      isCentered
+    >
+      <ModalOverlay />
+      <ModalContent mx={4}>
+        <ModalHeader>
+          <Text fontSize="xl" fontWeight="medium">プロフィール設定</Text>
+          <Text fontSize="sm" color="gray.500" fontWeight="normal" mt={1}>
+            アカウント情報を入力してください
+          </Text>
+        </ModalHeader>
+
+        <ModalBody>
+          <VStack as="form" id="profile-form" onSubmit={handleSubmit} spacing={4} align="stretch">
+            {error && (
+              <Box
+                bg="danger.50"
+                border="1px solid"
+                borderColor="danger.200"
+                borderRadius="md"
+                px={3}
+                py={2}
+              >
+                <Text fontSize="sm" color="danger.600">{error}</Text>
+              </Box>
+            )}
+
+            <Input
+              label="表示名 *"
+              id="displayName"
+              type="text"
+              placeholder="アプリ内で表示される名前"
+              value={displayName}
+              onChange={(e) => setDisplayName(e.target.value)}
+            />
+
+            <SimpleGrid columns={2} spacing={3}>
+              <Input
+                label="姓"
+                id="familyName"
+                type="text"
+                placeholder="山田"
+                value={familyName}
+                onChange={(e) => setFamilyName(e.target.value)}
+              />
+              <Input
+                label="名"
+                id="firstName"
+                type="text"
+                placeholder="太郎"
+                value={firstName}
+                onChange={(e) => setFirstName(e.target.value)}
+              />
+            </SimpleGrid>
+
+            <Input
+              label="電話番号"
+              id="phoneNumber"
+              type="tel"
+              placeholder="090-0000-0000"
+              value={phoneNumber}
+              onChange={(e) => setPhoneNumber(e.target.value)}
+            />
+
+            <Input
+              label="生年月日"
+              id="birthday"
+              type="date"
+              value={birthday}
+              onChange={(e) => setBirthday(e.target.value)}
+            />
+          </VStack>
+        </ModalBody>
+
+        <ModalFooter>
+          <Button
+            type="submit"
+            form="profile-form"
+            isLoading={isLoading}
+            isDisabled={displayName.trim() === ''}
+            w="full"
+          >
+            始める
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  )
+}

--- a/src/components/Auth/SignupForm.tsx
+++ b/src/components/Auth/SignupForm.tsx
@@ -7,12 +7,12 @@ import { Button } from '../ui/Button'
 import { Input } from '../ui/Input'
 import { Card } from '../ui/Card'
 
-interface LoginFormProps {
-  onSwitchToSignup?: () => void
+interface SignupFormProps {
+  onSwitchToLogin: () => void
 }
 
-export function LoginForm({ onSwitchToSignup }: LoginFormProps) {
-  const { signInWithEmail, signInWithGoogle } = useAuth()
+export function SignupForm({ onSwitchToLogin }: SignupFormProps) {
+  const { signUpWithEmail, signInWithGoogle } = useAuth()
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [error, setError] = useState<string | null>(null)
@@ -22,9 +22,10 @@ export function LoginForm({ onSwitchToSignup }: LoginFormProps) {
     e.preventDefault()
     setError(null)
     setIsLoading(true)
-    const { error } = await signInWithEmail(email, password)
+    const { error } = await signUpWithEmail(email, password)
     setIsLoading(false)
     if (error) setError(error.message)
+    // サインアップ成功時は onAuthStateChange が user をセットするのでここでは何もしない
   }
 
   return (
@@ -36,7 +37,7 @@ export function LoginForm({ onSwitchToSignup }: LoginFormProps) {
               Daily Share
             </Text>
             <Text fontSize="sm" color="gray.500" mt={1}>
-              アカウントにログインしてください
+              アカウントを作成してください
             </Text>
           </Box>
 
@@ -65,12 +66,12 @@ export function LoginForm({ onSwitchToSignup }: LoginFormProps) {
               label="パスワード"
               id="password"
               type="password"
-              placeholder="パスワードを入力"
+              placeholder="パスワードを入力（6文字以上）"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
             />
             <Button type="submit" isLoading={isLoading} w="full">
-              ログイン
+              アカウント作成
             </Button>
           </VStack>
 
@@ -84,21 +85,19 @@ export function LoginForm({ onSwitchToSignup }: LoginFormProps) {
             Google でログイン
           </Button>
 
-          {onSwitchToSignup && (
-            <Text textAlign="center" fontSize="sm" color="gray.500">
-              アカウントをお持ちでないですか？
-              {' '}
-              <Box
-                as="span"
-                color="primary.400"
-                cursor="pointer"
-                fontWeight="medium"
-                onClick={onSwitchToSignup}
-              >
-                新規登録
-              </Box>
-            </Text>
-          )}
+          <Text textAlign="center" fontSize="sm" color="gray.500">
+            すでにアカウントをお持ちですか？
+            {' '}
+            <Box
+              as="span"
+              color="primary.400"
+              cursor="pointer"
+              fontWeight="medium"
+              onClick={onSwitchToLogin}
+            >
+              ログイン
+            </Box>
+          </Text>
         </VStack>
       </Card>
     </Flex>

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -33,5 +33,20 @@ export function useAuth() {
 
   const signOut = () => supabase.auth.signOut()
 
-  return { user, session, loading, signInWithEmail, signUpWithEmail, signInWithGoogle, signOut }
+  const updateProfile = (
+    userId: string,
+    values: {
+      displayName: string
+      firstName?: string | null
+      familyName?: string | null
+      phoneNumber?: string | null
+      birthday?: string | null
+    }
+  ) =>
+    supabase
+      .from('users')
+      .update(values)
+      .eq('id', userId)
+
+  return { user, session, loading, signInWithEmail, signUpWithEmail, signInWithGoogle, signOut, updateProfile }
 }

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -37,6 +37,7 @@ export type Database = {
           birthday?: string | null
           createdAt?: string | null
         }
+        Relationships: []
       }
       teams: {
         Row: {
@@ -57,6 +58,7 @@ export type Database = {
           invitationalCode?: string
           createdAt?: string | null
         }
+        Relationships: []
       }
       user_teams: {
         Row: {
@@ -80,6 +82,7 @@ export type Database = {
           role?: string
           joinedAt?: string | null
         }
+        Relationships: []
       }
       user_friends: {
         Row: {
@@ -100,6 +103,7 @@ export type Database = {
           friendId?: string
           createdAt?: string | null
         }
+        Relationships: []
       }
       events: {
         Row: {
@@ -135,6 +139,7 @@ export type Database = {
           sharingState?: 'private' | 'friends' | 'team'
           createdAt?: string | null
         }
+        Relationships: []
       }
       locations: {
         Row: {
@@ -158,10 +163,11 @@ export type Database = {
           sharingState?: 'private' | 'friends' | 'team'
           updatedAt?: string | null
         }
+        Relationships: []
       }
     }
-    Views: Record<string, never>
-    Functions: Record<string, never>
+    Views: { [_ in never]: never }
+    Functions: { [_ in never]: never }
     Enums: {
       sharing_state: 'private' | 'friends' | 'team'
     }


### PR DESCRIPTION
## Summary

- `SignupForm`: ログインと分離した新規登録フォームを新規作成
- `ProfileSetupModal`: サインアップ後にプロフィール入力を促すモーダルを新規作成（表示名必須、姓・名・電話番号・生年月日は任意）
- `LoginForm`: `onSwitchToSignup` prop を追加してサインアップロジックを分離
- `useAuth`: `updateProfile` 関数を追加
- `App`: ログイン → サインアップ → プロフィール入力 → Map のフローを実装
- `database.ts`: `Relationships` / `Views` / `Functions` の型を supabase-js v2.99 に合わせて修正

## Test plan

- [ ] 新規登録 → プロフィールモーダルが自動表示される
- [ ] 表示名未入力では「始める」ボタンが無効
- [ ] プロフィール入力完了後に Map へ遷移する
- [ ] 既存ユーザー（displayName 設定済み）はモーダルが表示されず直接 Map へ
- [ ] ログイン画面から「新規登録」リンクで SignupForm へ遷移できる
- [ ] `npm run build` が通る

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)