### PR TITLE
feat: AuthProvider with shared auth state and improved team join flow

### DIFF
--- a/src/components/Auth/LoginForm.tsx
+++ b/src/components/Auth/LoginForm.tsx
@@ -22,9 +22,9 @@ export function LoginForm({ onSwitchToSignup }: LoginFormProps) {
     e.preventDefault()
     setError(null)
     setIsLoading(true)
-    const { error } = await signInWithEmail(email, password)
+    const result = await signInWithEmail(email, password)
     setIsLoading(false)
-    if (error) setError(error.message)
+    if (result.error) setError(result.error.message)
   }
 
   return (

--- a/src/components/Auth/ProfileSetupModal.tsx
+++ b/src/components/Auth/ProfileSetupModal.tsx
@@ -34,13 +34,49 @@ export function ProfileSetupModal({ isOpen, onComplete }: ProfileSetupModalProps
     e.preventDefault()
     if (!user) return
     setError(null)
+    
+    // バリデーション
+    if (!displayName.trim()) {
+      setError('表示名を入力してください')
+      return
+    }
+
+    // 電話番号のバリデーション（空白のみ、またはスペース除外後に空文字列なら null）
+    const trimmedPhone = phoneNumber.trim()
+    const validPhone = trimmedPhone === '' ? null : trimmedPhone
+
+    // 誕生日のバリデーション
+    const validBirthday: string | null = birthday || null
+    if (validBirthday) {
+      const birthDate = new Date(validBirthday)
+      const today = new Date()
+      
+      // 未来の日付チェック
+      if (birthDate > today) {
+        setError('生年月日は今日より前の日付を設定してください')
+        return
+      }
+
+      // 年齢チェック（0歳〜150歳の範囲）
+      const age = today.getFullYear() - birthDate.getFullYear()
+      const monthDiff = today.getMonth() - birthDate.getMonth()
+      const actualAge = monthDiff < 0 || (monthDiff === 0 && today.getDate() < birthDate.getDate()) 
+        ? age - 1 
+        : age
+
+      if (actualAge < 0 || actualAge > 150) {
+        setError('有効な生年月日を入力してください')
+        return
+      }
+    }
+
     setIsLoading(true)
     const result = await updateProfile(user.id, {
       displayName: displayName.trim(),
-      familyName: familyName || null,
-      firstName: firstName || null,
-      phoneNumber: phoneNumber || null,
-      birthday: birthday || null,
+      familyName: familyName.trim() || null,
+      firstName: firstName.trim() || null,
+      phoneNumber: validPhone,
+      birthday: validBirthday,
     })
     setIsLoading(false)
     if (result.error) {

--- a/src/components/Auth/ProfileSetupModal.tsx
+++ b/src/components/Auth/ProfileSetupModal.tsx
@@ -35,7 +35,7 @@ export function ProfileSetupModal({ isOpen, onComplete }: ProfileSetupModalProps
     if (!user) return
     setError(null)
     setIsLoading(true)
-    const { error } = await updateProfile(user.id, {
+    const result = await updateProfile(user.id, {
       displayName: displayName.trim(),
       familyName: familyName || null,
       firstName: firstName || null,
@@ -43,8 +43,8 @@ export function ProfileSetupModal({ isOpen, onComplete }: ProfileSetupModalProps
       birthday: birthday || null,
     })
     setIsLoading(false)
-    if (error) {
-      setError(error.message)
+    if (result.error) {
+      setError(result.error.message)
     } else {
       onComplete()
     }

--- a/src/components/Auth/SignupForm.tsx
+++ b/src/components/Auth/SignupForm.tsx
@@ -22,9 +22,9 @@ export function SignupForm({ onSwitchToLogin }: SignupFormProps) {
     e.preventDefault()
     setError(null)
     setIsLoading(true)
-    const { error } = await signUpWithEmail(email, password)
+    const result = await signUpWithEmail(email, password)
     setIsLoading(false)
-    if (error) setError(error.message)
+    if (result.error) setError(result.error.message)
     // サインアップ成功時は onAuthStateChange が user をセットするのでここでは何もしない
   }
 

--- a/src/components/AuthGuard.tsx
+++ b/src/components/AuthGuard.tsx
@@ -3,8 +3,8 @@ import { useAuth } from '../hooks/useAuth'
 import { LoadingSpinner } from './ui/LoadingSpinner'
 import { LoginForm } from './Auth/LoginForm'
 import { SignupForm } from './Auth/SignupForm'
-import { ProfileSetupModal } from './Auth/ProfileSetupModal.tsx'
-import { TeamSetup } from './Auth/TeamSetup.tsx'
+import { ProfileSetupModal } from './Auth/ProfileSetupModal'
+import { TeamSetup } from './Team/TeamSetup'
 
 interface AuthGuardProps {
   children: ReactNode

--- a/src/components/Team/TeamSetup.tsx
+++ b/src/components/Team/TeamSetup.tsx
@@ -1,0 +1,208 @@
+import { useState } from 'react'
+import {
+  Button,
+  Input,
+  VStack,
+  Text,
+  Tabs,
+  TabList,
+  TabPanels,
+  Tab,
+  TabPanel,
+  Stack,
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  ModalCloseButton,
+  useClipboard,
+} from '@chakra-ui/react'
+import { supabase } from '../../lib/supabase'
+import { useAuth } from '../../hooks/useAuth'
+import type { Database } from '../../types/database'
+
+type TeamInsert = Database['public']['Tables']['teams']['Insert']
+type UserTeamInsert = Database['public']['Tables']['user_teams']['Insert']
+
+type JoinResult = {
+  id: string
+  teamName: string
+  invitationalCode: string
+  createdAt: string | null
+}
+
+export function TeamSetup() {
+  const { user, refreshProfile } = useAuth()
+  const [teamName, setTeamName] = useState('')
+  const [invitationalCode, setInvitationalCode] = useState('')
+  const [createError, setCreateError] = useState<string | null>(null)
+  const [joinError, setJoinError] = useState<string | null>(null)
+  const [isCreating, setIsCreating] = useState(false)
+  const [isJoining, setIsJoining] = useState(false)
+  const [createdCode, setCreatedCode] = useState<string | null>(null)
+  const [isModalOpen, setIsModalOpen] = useState(false)
+  const { hasCopied, onCopy } = useClipboard(createdCode ?? '')
+
+  const handleCreateTeam = async () => {
+    if (!user) return
+    setCreateError(null)
+    if (!teamName.trim()) {
+      setCreateError('チーム名を入力してください')
+      return
+    }
+
+    setIsCreating(true)
+    try {
+      const invitationalCodeValue = Math.random().toString(36).slice(2, 8)
+      const { data: teamData, error: teamError } = await supabase
+        .from('teams')
+        .insert([{ teamName: teamName.trim(), invitationalCode: invitationalCodeValue } as TeamInsert])
+        .select()
+        .single()
+
+      if (teamError || !teamData) {
+        setCreateError(teamError?.message ?? 'チーム作成に失敗しました')
+        return
+      }
+
+      const { error: utError } = await supabase
+        .from('user_teams')
+        .insert([{ userId: user.id, teamId: teamData.id, role: 'admin' } as UserTeamInsert])
+
+      if (utError) {
+        setCreateError(utError.message)
+        return
+      }
+
+      setCreatedCode(invitationalCodeValue)
+      setIsModalOpen(true)
+    } catch (error: unknown) {
+      setCreateError(error instanceof Error ? error.message : String(error))
+    } finally {
+      setIsCreating(false)
+    }
+  }
+
+  const handleJoinTeam = async () => {
+    if (!user) return
+    setJoinError(null)
+    if (!invitationalCode.trim()) {
+      setJoinError('招待コードを入力してください')
+      return
+    }
+
+    setIsJoining(true)
+    try {
+      const { data: teamData, error: teamError } = await supabase
+        .from('teams')
+        .select('*')
+        .eq('invitationalCode', invitationalCode.trim())
+        .maybeSingle() as { data: JoinResult | null; error: { message: string } | null }
+
+      if (teamError) {
+        setJoinError(teamError.message)
+        return
+      }
+
+      if (!teamData) {
+        setJoinError('招待コードが存在しません')
+        return
+      }
+
+      const { error: utError } = await supabase
+        .from('user_teams')
+        .insert([{ userId: user.id, teamId: teamData.id, role: 'member' } as UserTeamInsert])
+
+      if (utError) {
+        setJoinError(utError.message)
+        return
+      }
+
+      await refreshProfile()
+    } catch (error: unknown) {
+      setJoinError(error instanceof Error ? error.message : String(error))
+    } finally {
+      setIsJoining(false)
+    }
+  }
+
+  return (
+    <VStack spacing={6} p={6} maxW="560px" margin="0 auto">
+      <Text fontSize="2xl" fontWeight="bold">
+        チーム設定
+      </Text>
+      <Tabs variant="enclosed" colorScheme="blue" isFitted>
+        <TabList>
+          <Tab>新規作成</Tab>
+          <Tab>招待コードで参加</Tab>
+        </TabList>
+
+        <TabPanels>
+          <TabPanel>
+            <Stack spacing={4}>
+              <Text>チーム名を入力して新しいチームを作成します。</Text>
+              <Input
+                value={teamName}
+                onChange={(e) => setTeamName(e.target.value)}
+                placeholder="チーム名"
+              />
+              {createError && <Text color="red.500">{createError}</Text>}
+              <Button onClick={handleCreateTeam} isLoading={isCreating} colorScheme="green">
+                チーム作成
+              </Button>
+            </Stack>
+          </TabPanel>
+
+          <TabPanel>
+            <Stack spacing={4}>
+              <Text>招待コードを入力して既存チームに参加します。</Text>
+              <Input
+                value={invitationalCode}
+                onChange={(e) => setInvitationalCode(e.target.value)}
+                placeholder="招待コード"
+              />
+              {joinError && <Text color="red.500">{joinError}</Text>}
+              <Button onClick={handleJoinTeam} isLoading={isJoining} colorScheme="blue">
+                参加する
+              </Button>
+            </Stack>
+          </TabPanel>
+        </TabPanels>
+      </Tabs>
+
+      <Modal isOpen={isModalOpen} onClose={() => setIsModalOpen(false)} isCentered>
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader>招待コードが発行されました</ModalHeader>
+          <ModalCloseButton />
+          <ModalBody>
+            <Text mb={3}>このコードをコピーして、参加したい人に共有してください。</Text>
+            <Text fontSize="lg" fontWeight="bold" mb={2}>
+              {createdCode}
+            </Text>
+            <Button onClick={onCopy} size="sm" mb={3}>
+              {hasCopied ? 'コピーしました' : 'コピー'}
+            </Button>
+            <Text fontSize="sm" color="gray.500">
+              このコードは新しいメンバーが「招待コードで参加」タブに入力するものです。
+            </Text>
+          </ModalBody>
+          <ModalFooter>
+            <Button
+              colorScheme="blue"
+              mr={3}
+              onClick={async () => {
+                setIsModalOpen(false)
+                await refreshProfile()
+              }}
+            >
+              閉じる
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </VStack>
+  )
+}

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -6,7 +6,7 @@ import {
   useCallback,
   type ReactNode,
 } from 'react'
-import type { User, Session } from '@supabase/supabase-js'
+import type { User, Session, AuthError } from '@supabase/supabase-js'
 import { supabase } from '../lib/supabase'
 import type { Database } from '../types/database'
 
@@ -16,6 +16,11 @@ type UserTeamId = Pick<Database['public']['Tables']['user_teams']['Row'], 'teamI
 
 type UserUpdate = Database['public']['Tables']['users']['Update']
 
+type AuthResponse = { data: { user: User; session: Session } | { user: null; session: null }; error: AuthError | null }
+type SignOutResponse = { error: AuthError | null }
+type OAuthResponse = { data: { provider: string; url: string }; error: AuthError | null }
+type DatabaseResponse<T> = { data: T | null; error: { message: string } | null }
+
 type AuthContextValue = {
   user: User | null
   session: Session | null
@@ -24,11 +29,11 @@ type AuthContextValue = {
   loading: boolean
   displayNameMissing: boolean
   refreshProfile: () => Promise<void>
-  updateProfile: (userId: string, values: UserUpdate) => Promise<any>
-  signInWithEmail: (email: string, password: string) => Promise<any>
-  signUpWithEmail: (email: string, password: string) => Promise<any>
-  signInWithGoogle: () => Promise<any>
-  signOut: () => Promise<any>
+  updateProfile: (userId: string, values: UserUpdate) => Promise<DatabaseResponse<Profile>>
+  signInWithEmail: (email: string, password: string) => Promise<AuthResponse>
+  signUpWithEmail: (email: string, password: string) => Promise<AuthResponse>
+  signInWithGoogle: () => Promise<OAuthResponse>
+  signOut: () => Promise<SignOutResponse>
 }
 
 const AuthContext = createContext<AuthContextValue | undefined>(undefined)
@@ -144,6 +149,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   return <AuthContext.Provider value={auth}>{children}</AuthContext.Provider>
 }
 
+// eslint-disable-next-line react-refresh/only-export-components
 export function useAuth() {
   const context = useContext(AuthContext)
   if (!context) {

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -16,9 +16,9 @@ type UserTeamId = Pick<Database['public']['Tables']['user_teams']['Row'], 'teamI
 
 type UserUpdate = Database['public']['Tables']['users']['Update']
 
-type AuthResponse = { data: { user: User; session: Session } | { user: null; session: null }; error: AuthError | null }
+type AuthResponse = { data: { user: User | null; session: Session | null }; error: AuthError | null }
 type SignOutResponse = { error: AuthError | null }
-type OAuthResponse = { data: { provider: string; url: string }; error: AuthError | null }
+type OAuthResponse = { data: { provider: string; url: string | null }; error: AuthError | null }
 type DatabaseResponse<T> = { data: T | null; error: { message: string } | null }
 
 type AuthContextValue = {

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -1,4 +1,11 @@
-import { useEffect, useState, useCallback } from 'react'
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  useCallback,
+  type ReactNode,
+} from 'react'
 import type { User, Session } from '@supabase/supabase-js'
 import { supabase } from '../lib/supabase'
 import type { Database } from '../types/database'
@@ -9,7 +16,24 @@ type UserTeamId = Pick<Database['public']['Tables']['user_teams']['Row'], 'teamI
 
 type UserUpdate = Database['public']['Tables']['users']['Update']
 
-export function useAuth() {
+type AuthContextValue = {
+  user: User | null
+  session: Session | null
+  profile: Profile | null
+  teams: Array<Team>
+  loading: boolean
+  displayNameMissing: boolean
+  refreshProfile: () => Promise<void>
+  updateProfile: (userId: string, values: UserUpdate) => Promise<any>
+  signInWithEmail: (email: string, password: string) => Promise<any>
+  signUpWithEmail: (email: string, password: string) => Promise<any>
+  signInWithGoogle: () => Promise<any>
+  signOut: () => Promise<any>
+}
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined)
+
+function useProvideAuth() {
   const [user, setUser] = useState<User | null>(null)
   const [session, setSession] = useState<Session | null>(null)
   const [profile, setProfile] = useState<Profile | null>(null)
@@ -23,7 +47,6 @@ export function useAuth() {
       return
     }
 
-    // fetch profile from `users` table (new schema)
     const { data: profileData, error: profileError } = await supabase
       .from('users')
       .select('*')
@@ -37,7 +60,6 @@ export function useAuth() {
       setProfile(profileData ?? null)
     }
 
-    // fetch user_teams rows, then load teams
     const { data: userTeamsData, error: utError } = await supabase
       .from('user_teams')
       .select('teamId')
@@ -81,27 +103,25 @@ export function useAuth() {
     return () => subscription.unsubscribe()
   }, [fetchProfileAndTeams])
 
-  const signInWithEmail = (email: string, password: string) =>
-    supabase.auth.signInWithPassword({ email, password })
+  const signInWithEmail = async (email: string, password: string) =>
+    await supabase.auth.signInWithPassword({ email, password })
 
-  const signUpWithEmail = (email: string, password: string) =>
-    supabase.auth.signUp({ email, password })
+  const signUpWithEmail = async (email: string, password: string) =>
+    await supabase.auth.signUp({ email, password })
 
-  const signInWithGoogle = () => supabase.auth.signInWithOAuth({ provider: 'google' })
+  const signInWithGoogle = async () =>
+    await supabase.auth.signInWithOAuth({ provider: 'google' })
 
-  const signOut = () => supabase.auth.signOut()
+  const signOut = async () => await supabase.auth.signOut()
+
+  const updateProfile = async (userId: string, values: UserUpdate) =>
+    await supabase.from('users').update(values).eq('id', userId).select().single()
 
   const refreshProfile = async () => {
     await fetchProfileAndTeams(user?.id)
   }
 
   const displayNameMissing = !profile || !profile.displayName || profile.displayName.trim() === ''
-
-  const updateProfile = (userId: string, values: UserUpdate) =>
-    supabase
-      .from('users')
-      .update(values)
-      .eq('id', userId)
 
   return {
     user,
@@ -117,4 +137,17 @@ export function useAuth() {
     signInWithGoogle,
     signOut,
   }
+}
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const auth = useProvideAuth()
+  return <AuthContext.Provider value={auth}>{children}</AuthContext.Provider>
+}
+
+export function useAuth() {
+  const context = useContext(AuthContext)
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider')
+  }
+  return context
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,9 +3,12 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
+import { AuthProvider } from './hooks/useAuth'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <AuthProvider>
+      <App />
+    </AuthProvider>
   </StrictMode>,
 )


### PR DESCRIPTION
## 概要 feat: TeamSetup 画面を新規作成


Closes #5 

## 変更内容
- issueに書いてあること
- SQLをいったん条件をtrueに変更。
- 電話番号と年齢フィルタ

## 確認方法
```bash
# 動作確認の手順を書く
npm run dev
```

## スクリーンショット（UIの変更がある場合）
<!-- 変更前・変更後の画像を貼る -->

## チェックリスト
- [x] `npm run lint` が通る
- [x] `npm run build` が通る
- [x] 動作確認済み
- [x] レビュアーを設定した
