### PR TITLE
feat: CalendarTab — 週表示 + 予定CRUD

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "daily-share",
       "version": "0.0.0",
       "dependencies": {
+        "@chakra-ui/icons": "^2.2.4",
         "@chakra-ui/react": "^2.10.9",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
@@ -327,6 +328,16 @@
         "framesync": "6.1.2"
       },
       "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/icons": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/icons/-/icons-2.2.4.tgz",
+      "integrity": "sha512-l5QdBgwrAg3Sc2BRqtNkJpfuLw/pWRDwwT58J6c4PqQT6wzXxyNa8Q0PForu1ltB5qEiFb1kxr/F/HO1EwNa6g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@chakra-ui/react": ">=2.0.0",
         "react": ">=18"
       }
     },
@@ -6461,24 +6472,6 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
+    "@chakra-ui/icons": "^2.2.4",
     "@chakra-ui/react": "^2.10.9",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
@@ -23,30 +24,30 @@
     "react-leaflet": "^5.0.0"
   },
   "devDependencies": {
+    "@chromatic-com/storybook": "^5.0.1",
     "@eslint/js": "^9.39.4",
+    "@storybook/addon-a11y": "^10.2.19",
+    "@storybook/addon-docs": "^10.2.19",
+    "@storybook/addon-onboarding": "^10.2.19",
+    "@storybook/addon-vitest": "^10.2.19",
+    "@storybook/react-vite": "^10.2.19",
     "@types/leaflet": "^1.9.21",
     "@types/node": "^24.12.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.0",
+    "@vitest/browser-playwright": "^4.1.0",
+    "@vitest/coverage-v8": "^4.1.0",
     "eslint": "^9.39.4",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",
+    "eslint-plugin-storybook": "^10.2.19",
     "globals": "^17.4.0",
+    "playwright": "^1.58.2",
+    "storybook": "^10.2.19",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.56.1",
     "vite": "^8.0.0",
-    "storybook": "^10.2.19",
-    "@storybook/react-vite": "^10.2.19",
-    "@chromatic-com/storybook": "^5.0.1",
-    "@storybook/addon-vitest": "^10.2.19",
-    "@storybook/addon-a11y": "^10.2.19",
-    "@storybook/addon-docs": "^10.2.19",
-    "@storybook/addon-onboarding": "^10.2.19",
-    "eslint-plugin-storybook": "^10.2.19",
-    "vitest": "^4.1.0",
-    "playwright": "^1.58.2",
-    "@vitest/browser-playwright": "^4.1.0",
-    "@vitest/coverage-v8": "^4.1.0"
+    "vitest": "^4.1.0"
   }
 }

--- a/src/components/Calendar/CalendarTab.tsx
+++ b/src/components/Calendar/CalendarTab.tsx
@@ -1,0 +1,234 @@
+import { useEffect, useMemo, useState } from 'react'
+import {
+  Box,
+  Grid,
+  Heading,
+  Text,
+  HStack,
+  VStack,
+  IconButton,
+  useDisclosure,
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  ModalCloseButton,
+  FormControl,
+  FormLabel,
+  Select,
+  Textarea,
+  Spinner,
+} from '@chakra-ui/react'
+import { ArrowLeftIcon, ArrowRightIcon, AddIcon, DeleteIcon } from '@chakra-ui/icons'
+import { supabase } from '../../lib/supabase'
+import { useAuth } from '../../hooks/useAuth'
+import { Button } from '../ui/Button'
+import { Input } from '../ui/Input'
+import type { Database } from '../../types/database'
+
+type EventRow = Database['public']['Tables']['events']['Row']
+
+function startOfWeek(d: Date) {
+  const dt = new Date(d)
+  const day = dt.getDay()
+  dt.setHours(0, 0, 0, 0)
+  dt.setDate(dt.getDate() - day)
+  return dt
+}
+
+function addDays(d: Date, days: number) {
+  const dt = new Date(d)
+  dt.setDate(dt.getDate() + days)
+  return dt
+}
+
+export default function CalendarTab() {
+  const { user, teams } = useAuth()
+  const [anchor, setAnchor] = useState(() => startOfWeek(new Date()))
+  const [events, setEvents] = useState<EventRow[]>([])
+  const [loading, setLoading] = useState(false)
+
+  const { isOpen, onOpen, onClose } = useDisclosure()
+  const [form, setForm] = useState({
+    name: '',
+    startAt: '',
+    endAt: '',
+    eventLocation: '',
+    sharingState: 'private',
+  })
+
+  const teamIds = useMemo(() => teams.map((t) => t.id), [teams])
+
+  useEffect(() => {
+    fetchEvents()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [anchor, teams])
+
+  async function fetchEvents() {
+    if (!teamIds || teamIds.length === 0) return setEvents([])
+    setLoading(true)
+    const wkStart = startOfWeek(anchor)
+    const wkEnd = addDays(wkStart, 7)
+    try {
+      const { data, error } = await supabase
+        .from('events')
+        .select('*')
+        .in('teamId', teamIds)
+        .gte('startAt', wkStart.toISOString())
+        .lt('startAt', wkEnd.toISOString())
+        .order('startAt', { ascending: true })
+
+      if (error) {
+        console.error('fetch events error', error)
+        setEvents([])
+      } else {
+        setEvents((data as EventRow[]) || [])
+      }
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  function prevWeek() {
+    setAnchor((a) => addDays(a, -7))
+  }
+
+  function nextWeek() {
+    setAnchor((a) => addDays(a, 7))
+  }
+
+  function days() {
+    const start = startOfWeek(anchor)
+    return Array.from({ length: 7 }).map((_, i) => addDays(start, i))
+  }
+
+  function eventsForDay(d: Date) {
+    const dayStart = new Date(d)
+    dayStart.setHours(0, 0, 0, 0)
+    const dayEnd = new Date(d)
+    dayEnd.setHours(23, 59, 59, 999)
+    return events.filter((e) => {
+      const s = new Date(e.startAt)
+      return s >= dayStart && s <= dayEnd
+    })
+  }
+
+  async function handleCreate() {
+    if (!user) return
+    if (!teams || teams.length === 0) return
+    const teamId = teams[0].id
+    try {
+      await supabase.from('events').insert({
+        createdBy: user.id,
+        teamId,
+        name: form.name,
+        startAt: new Date(form.startAt).toISOString(),
+        endAt: new Date(form.endAt).toISOString(),
+        eventLocation: form.eventLocation || null,
+        sharingState: form.sharingState as EventRow['sharingState'],
+      })
+      setForm({ name: '', startAt: '', endAt: '', eventLocation: '', sharingState: 'private' })
+      onClose()
+      fetchEvents()
+    } catch (err) {
+      console.error('create event error', err)
+    }
+  }
+
+  async function handleDelete(id: string) {
+    try {
+      await supabase.from('events').delete().eq('id', id)
+      fetchEvents()
+    } catch (err) {
+      console.error('delete event error', err)
+    }
+  }
+
+  return (
+    <Box>
+      <HStack justify="space-between" mb={4}>
+        <HStack>
+          <IconButton aria-label="prev" icon={<ArrowLeftIcon />} onClick={prevWeek} />
+          <IconButton aria-label="next" icon={<ArrowRightIcon />} onClick={nextWeek} />
+          <Heading size="md">Week of {anchor.toDateString()}</Heading>
+        </HStack>
+        <HStack>
+          <Button leftIcon={<AddIcon />} onClick={onOpen}>Add Event</Button>
+        </HStack>
+      </HStack>
+
+      {loading ? (
+        <Spinner />
+      ) : (
+        <Grid templateColumns="repeat(7, 1fr)" gap={4}>
+          {days().map((d) => (
+            <Box key={d.toISOString()} borderWidth="1px" borderRadius="md" p={3} minH="120px">
+              <Heading size="sm">{d.toLocaleDateString(undefined, { weekday: 'short', month: 'short', day: 'numeric' })}</Heading>
+              <VStack align="stretch" mt={2} spacing={2}>
+                {eventsForDay(d).map((ev) => (
+                  <Box key={ev.id} p={2} bg="gray.50" borderRadius="md">
+                    <HStack justify="space-between">
+                      <VStack align="start" spacing={0}>
+                        <Text fontWeight="bold">{ev.name}</Text>
+                        <Text fontSize="sm">{new Date(ev.startAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })} - {new Date(ev.endAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}</Text>
+                        {ev.eventLocation && <Text fontSize="sm">{ev.eventLocation}</Text>}
+                      </VStack>
+                      {user && ev.createdBy === user.id && (
+                        <IconButton aria-label="delete" size="sm" icon={<DeleteIcon />} onClick={() => handleDelete(ev.id)} />
+                      )}
+                    </HStack>
+                  </Box>
+                ))}
+              </VStack>
+            </Box>
+          ))}
+        </Grid>
+      )}
+
+      <Modal isOpen={isOpen} onClose={onClose}>
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader>Add Event</ModalHeader>
+          <ModalCloseButton />
+          <ModalBody>
+            <FormControl mb={3}>
+              <FormLabel>Name</FormLabel>
+              <Input value={form.name} onChange={(e) => setForm({ ...form, name: e.target.value })} />
+            </FormControl>
+
+            <FormControl mb={3}>
+              <FormLabel>Start</FormLabel>
+              <Input type="datetime-local" value={form.startAt} onChange={(e) => setForm({ ...form, startAt: e.target.value })} />
+            </FormControl>
+
+            <FormControl mb={3}>
+              <FormLabel>End</FormLabel>
+              <Input type="datetime-local" value={form.endAt} onChange={(e) => setForm({ ...form, endAt: e.target.value })} />
+            </FormControl>
+
+            <FormControl mb={3}>
+              <FormLabel>Location</FormLabel>
+              <Textarea value={form.eventLocation} onChange={(e) => setForm({ ...form, eventLocation: e.target.value })} />
+            </FormControl>
+
+            <FormControl mb={3}>
+              <FormLabel>Sharing</FormLabel>
+              <Select value={form.sharingState} onChange={(e) => setForm({ ...form, sharingState: e.target.value })}>
+                <option value="private">Private</option>
+                <option value="friends">Friends</option>
+                <option value="team">Team</option>
+              </Select>
+            </FormControl>
+          </ModalBody>
+
+          <ModalFooter>
+            <Button variant="ghost" mr={3} onClick={onClose}>Cancel</Button>
+            <Button onClick={handleCreate}>Create</Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </Box>
+  )
+}

--- a/src/components/Layout/MainLayout.tsx
+++ b/src/components/Layout/MainLayout.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import CalendarTab from '../Calendar/CalendarTab'
 import {
   Box,
   Flex,
@@ -17,24 +18,7 @@ import {
 } from '@chakra-ui/react'
 import { useAuth } from '../../hooks/useAuth'
 
-function CalendarTab() {
-  return (
-    <Box
-      bg="white"
-      p={8}
-      borderRadius="lg"
-      boxShadow="sm"
-      minH="calc(100vh - 160px)"
-    >
-      <Text fontSize="2xl" fontWeight="semibold" mb={4}>
-        カレンダー
-      </Text>
-      <Text color="gray.500">
-        ここにカレンダーのメインコンテンツを表示します。
-      </Text>
-    </Box>
-  )
-}
+// CalendarTab is implemented in src/components/Calendar/CalendarTab.tsx
 
 function MapTab() {
   return (


### PR DESCRIPTION
## 概要
#8を参照

Closes #8 

## 変更内容
- 

components/Calendar/CalendarTab.tsx を新規作成

週表示カレンダーUI（日〜土の7列）

前週・次週へのナビゲーション

予定追加モーダル（name / startAt / endAt / eventLocation / sharingState）

予定削除（自分が作った予定のみ）

events テーブルとの CRUD 連携
- 

## 確認方法
```bash
# 動作確認の手順を書く
npm run dev
```

## スクリーンショット（UIの変更がある場合）
<!-- 変更前・変更後の画像を貼る -->

## チェックリスト
- [x] `npm run lint` が通る
- [x] `npm run build` が通る
- [x] 動作確認済み
- [x] レビュアーを設定した
