### PR TITLE
feat(calendar): 日/週/月ビュー・ビューセレクタ・サイドバー

### DIFF
--- a/src/components/Calendar/CalendarSidebar.tsx
+++ b/src/components/Calendar/CalendarSidebar.tsx
@@ -1,0 +1,130 @@
+import { useState } from 'react'
+import { Box, Flex, Grid, Text, VStack, HStack, IconButton, Checkbox, Center } from '@chakra-ui/react'
+import { ChevronLeftIcon, ChevronRightIcon, AddIcon } from '@chakra-ui/icons'
+import { Button } from '../ui/Button'
+import {
+  WEEKDAYS,
+  SHARING,
+  addMonths,
+  monthGridDays,
+  isSameDay,
+  isSameMonth,
+  type SharingState,
+} from './calendarUtils'
+
+interface CalendarSidebarProps {
+  anchor: Date
+  now: Date
+  onPickDate: (day: Date) => void
+  onCreate: () => void
+  filters: Set<SharingState>
+  onToggleFilter: (s: SharingState) => void
+}
+
+export function CalendarSidebar({
+  anchor,
+  now,
+  onPickDate,
+  onCreate,
+  filters,
+  onToggleFilter,
+}: CalendarSidebarProps) {
+  // The month shown in the mini calendar (independent of the main anchor).
+  const [miniMonth, setMiniMonth] = useState(() => new Date(anchor))
+  const days = monthGridDays(miniMonth)
+
+  return (
+    <Box w="260px" flexShrink={0} display={{ base: 'none', lg: 'block' }} pr={6}>
+      <Button
+        variant="signal"
+        leftIcon={<AddIcon boxSize={3} />}
+        onClick={onCreate}
+        mb={6}
+        boxShadow="md"
+      >
+        作成
+      </Button>
+
+      {/* Mini month calendar */}
+      <Box mb={6}>
+        <Flex align="center" justify="space-between" mb={2}>
+          <Text fontFamily="heading" fontWeight="700" fontSize="sm" color="gray.900">
+            {miniMonth.getFullYear()}年 {miniMonth.getMonth() + 1}月
+          </Text>
+          <HStack spacing={0}>
+            <IconButton
+              aria-label="前の月"
+              icon={<ChevronLeftIcon />}
+              size="xs"
+              variant="ghost"
+              onClick={() => setMiniMonth((m) => addMonths(m, -1))}
+            />
+            <IconButton
+              aria-label="次の月"
+              icon={<ChevronRightIcon />}
+              size="xs"
+              variant="ghost"
+              onClick={() => setMiniMonth((m) => addMonths(m, 1))}
+            />
+          </HStack>
+        </Flex>
+
+        <Grid templateColumns="repeat(7, 1fr)" gap="2px">
+          {WEEKDAYS.map((w, i) => (
+            <Center key={w} h={6}>
+              <Text fontSize="10px" color={i === 0 ? 'danger.400' : i === 6 ? 'primary.400' : 'gray.400'}>
+                {w}
+              </Text>
+            </Center>
+          ))}
+          {days.map((d) => {
+            const today = isSameDay(d, now)
+            const selected = isSameDay(d, anchor)
+            const inMonth = isSameMonth(d, miniMonth)
+            return (
+              <Center key={d.toISOString()} h={7}>
+                <Center
+                  as="button"
+                  boxSize={7}
+                  borderRadius="full"
+                  fontSize="xs"
+                  fontWeight={today || selected ? '700' : '500'}
+                  color={
+                    selected ? 'white' : today ? 'signal.600' : inMonth ? 'gray.700' : 'gray.300'
+                  }
+                  bg={selected ? 'primary.500' : 'transparent'}
+                  _hover={{ bg: selected ? 'primary.600' : 'gray.100' }}
+                  onClick={() => onPickDate(d)}
+                >
+                  {d.getDate()}
+                </Center>
+              </Center>
+            )
+          })}
+        </Grid>
+      </Box>
+
+      {/* My calendars (filter by sharing scope) */}
+      <Box>
+        <Text fontSize="xs" fontWeight="bold" color="gray.500" mb={2} letterSpacing="wide">
+          マイカレンダー
+        </Text>
+        <VStack align="stretch" spacing={2}>
+          {(Object.keys(SHARING) as SharingState[]).map((key) => (
+            <Checkbox
+              key={key}
+              isChecked={filters.has(key)}
+              onChange={() => onToggleFilter(key)}
+              colorScheme={SHARING[key].colorScheme}
+              size="sm"
+            >
+              <Text fontSize="sm" color="gray.700">
+                {SHARING[key].label}
+              </Text>
+            </Checkbox>
+          ))}
+        </VStack>
+      </Box>
+    </Box>
+  )
+}

--- a/src/components/Calendar/CalendarTab.tsx
+++ b/src/components/Calendar/CalendarTab.tsx
@@ -1,276 +1,90 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import {
   Box,
-  Heading,
-  Text,
-  HStack,
-  VStack,
-  IconButton,
-  useDisclosure,
-  Modal,
-  ModalOverlay,
-  ModalContent,
-  ModalHeader,
-  ModalBody,
-  ModalFooter,
-  ModalCloseButton,
-  FormControl,
-  FormLabel,
-  Select,
-  Textarea,
-  Spinner,
   Flex,
-  Badge,
-  Center,
-  Switch,
-  Input as ChakraInput,
+  Heading,
+  HStack,
+  IconButton,
+  Menu,
+  MenuButton,
+  MenuList,
+  MenuItem,
+  useDisclosure,
   useToast,
+  Spinner,
+  Center,
 } from '@chakra-ui/react'
-import { ChevronLeftIcon, ChevronRightIcon, AddIcon, DeleteIcon } from '@chakra-ui/icons'
+import { ChevronLeftIcon, ChevronRightIcon, ChevronDownIcon, AddIcon } from '@chakra-ui/icons'
 import { supabase } from '../../lib/supabase'
 import { useAuth } from '../../hooks/useAuth'
 import { Button } from '../ui/Button'
-import { Input } from '../ui/Input'
-import type { Database } from '../../types/database'
+import { EventModal } from './EventModal'
+import { TimeGridView } from './TimeGridView'
+import { MonthView } from './MonthView'
+import { CalendarSidebar } from './CalendarSidebar'
+import {
+  EMPTY_FORM,
+  startOfWeek,
+  startOfDay,
+  addDays,
+  addMonths,
+  monthGridDays,
+  toDateInput,
+  minuteToTime,
+  type CalendarView,
+  type EventForm,
+  type EventRow,
+  type SharingState,
+} from './calendarUtils'
 
-type EventRow = Database['public']['Tables']['events']['Row']
-
-const WEEKDAYS = ['日', '月', '火', '水', '木', '金', '土']
-
-const HOUR_HEIGHT = 48 // px per hour
-const GUTTER = 56 // px — time labels column
-const TOTAL_HEIGHT = HOUR_HEIGHT * 24
-
-const SHARING = {
-  private: { label: '自分のみ', colorScheme: 'gray' },
-  friends: { label: '友だち', colorScheme: 'primary' },
-  team: { label: 'チーム', colorScheme: 'signal' },
-} as const
-
-// 15-minute time options: "00:00", "00:15", … "23:45". Used as datalist
-// suggestions so the time field offers a dropdown yet stays free-text.
-const TIME_OPTIONS = Array.from({ length: 96 }, (_, i) => {
-  const h = Math.floor(i / 4)
-  const m = (i % 4) * 15
-  return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`
-})
-
-// Event block colors per sharing state, aligned with the design system.
-const EVENT_STYLE = {
-  private: { bg: 'gray.100', accent: 'gray.400', text: 'gray.700', time: 'gray.500' },
-  friends: { bg: 'primary.50', accent: 'primary.500', text: 'primary.800', time: 'primary.600' },
-  team: { bg: 'signal.50', accent: 'signal.500', text: 'signal.800', time: 'signal.600' },
-} as const
-
-function startOfWeek(d: Date) {
-  const dt = new Date(d)
-  const day = dt.getDay()
-  dt.setHours(0, 0, 0, 0)
-  dt.setDate(dt.getDate() - day)
-  return dt
-}
-
-function addDays(d: Date, days: number) {
-  const dt = new Date(d)
-  dt.setDate(dt.getDate() + days)
-  return dt
-}
-
-function isSameDay(a: Date, b: Date) {
-  return (
-    a.getFullYear() === b.getFullYear() &&
-    a.getMonth() === b.getMonth() &&
-    a.getDate() === b.getDate()
-  )
-}
-
-function minutesOfDay(d: Date) {
-  return d.getHours() * 60 + d.getMinutes()
-}
-
-// Local "YYYY-MM-DD" for date inputs (avoids the UTC shift of toISOString).
-function toDateInput(d: Date) {
-  const y = d.getFullYear()
-  const m = String(d.getMonth() + 1).padStart(2, '0')
-  const dd = String(d.getDate()).padStart(2, '0')
-  return `${y}-${m}-${dd}`
-}
-
-// minutes-from-midnight → "HH:MM"
-function minuteToTime(min: number) {
-  const h = Math.floor(min / 60)
-  const m = min % 60
-  return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`
-}
-
-// Does the event's [start, end) range touch the given calendar day?
-function overlapsDay(ev: EventRow, day: Date) {
-  const ds = new Date(day)
-  ds.setHours(0, 0, 0, 0)
-  const de = addDays(ds, 1)
-  return new Date(ev.startAt) < de && new Date(ev.endAt) > ds
-}
-
-function formatTime(iso: string) {
-  return new Date(iso).toLocaleTimeString('ja-JP', { hour: '2-digit', minute: '2-digit' })
-}
-
-type Positioned = {
-  ev: EventRow
-  start: number // minutes from midnight (clamped to this day)
-  end: number
-  fromPrev: boolean // event began on an earlier day
-  toNext: boolean // event continues into a later day
-  colIndex: number
-  colCount: number
-}
-
-/**
- * Pack one day's events into side-by-side columns, Google-Calendar style.
- * Each event is sliced to the portion that falls on `day`, so multi-day and
- * overnight events appear on every day they cover (clamped to midnight bounds).
- */
-function layoutDay(day: Date, allEvents: EventRow[]): Positioned[] {
-  const dayStart = new Date(day)
-  dayStart.setHours(0, 0, 0, 0)
-  const dayEnd = addDays(dayStart, 1)
-
-  const items = allEvents
-    .map((ev) => {
-      if (ev.isAllDay) return null // all-day events live in their own row
-      const s = new Date(ev.startAt)
-      const e = new Date(ev.endAt)
-      // keep only events that overlap this day
-      if (!(s < dayEnd && e > dayStart)) return null
-      const start = s <= dayStart ? 0 : minutesOfDay(s)
-      const rawEnd = e >= dayEnd ? 24 * 60 : minutesOfDay(e)
-      const end = Math.min(Math.max(rawEnd, start + 20), 24 * 60) // min visible height
-      return { ev, start, end, fromPrev: s < dayStart, toNext: e > dayEnd }
-    })
-    .filter((x): x is NonNullable<typeof x> => x !== null)
-    .sort((a, b) => a.start - b.start || a.end - b.end)
-
-  const result: Positioned[] = []
-  let cluster: typeof items = []
-  let clusterEnd = -1
-
-  const flush = () => {
-    const colEnds: number[] = [] // last end time placed in each column
-    const colOf = new Map<EventRow, number>()
-    for (const it of cluster) {
-      let col = colEnds.findIndex((end) => it.start >= end)
-      if (col === -1) {
-        col = colEnds.length
-        colEnds.push(it.end)
-      } else {
-        colEnds[col] = it.end
-      }
-      colOf.set(it.ev, col)
-    }
-    const colCount = colEnds.length
-    for (const it of cluster) {
-      result.push({ ...it, colIndex: colOf.get(it.ev)!, colCount })
-    }
-    cluster = []
-    clusterEnd = -1
-  }
-
-  for (const it of items) {
-    if (cluster.length && it.start >= clusterEnd) flush()
-    cluster.push(it)
-    clusterEnd = Math.max(clusterEnd, it.end)
-  }
-  if (cluster.length) flush()
-  return result
-}
+const VIEW_LABEL: Record<CalendarView, string> = { day: '日', week: '週', month: '月' }
 
 export default function CalendarTab() {
   const { user, teams } = useAuth()
-  const [anchor, setAnchor] = useState(() => startOfWeek(new Date()))
+  const [view, setView] = useState<CalendarView>('week')
+  const [anchor, setAnchor] = useState(() => startOfDay(new Date()))
   const [events, setEvents] = useState<EventRow[]>([])
   const [loading, setLoading] = useState(false)
   const [now, setNow] = useState(() => new Date())
-  const scrollRef = useRef<HTMLDivElement>(null)
+  const [filters, setFilters] = useState<Set<SharingState>>(
+    () => new Set<SharingState>(['private', 'friends', 'team']),
+  )
 
   const { isOpen, onOpen, onClose } = useDisclosure()
   const toast = useToast()
-  const [form, setForm] = useState({
-    name: '',
-    isAllDay: false,
-    startDate: '',
-    startTime: '',
-    endDate: '',
-    endTime: '',
-    eventLocation: '',
-    sharingState: 'private',
-  })
-  // The slot currently hovered in the time grid (Google-style ghost),
-  // snapped to 15-minute increments (minutes from midnight).
-  const [hoverSlot, setHoverSlot] = useState<{ dayIso: string; minute: number } | null>(null)
-
-  // Convert a mouse event over a day column into minutes-from-midnight,
-  // snapped to the nearest 15 minutes (0 … 23:45).
-  function minuteFromPointer(e: React.MouseEvent<HTMLDivElement>) {
-    const rect = e.currentTarget.getBoundingClientRect()
-    const y = e.clientY - rect.top
-    const raw = (y / HOUR_HEIGHT) * 60
-    const snapped = Math.floor(raw / 15) * 15
-    return Math.max(0, Math.min(23 * 60 + 45, snapped))
-  }
-
-  // Open the add modal prefilled with the clicked day + 1-hour slot.
-  function openSlot(day: Date, minute: number) {
-    const dateStr = toDateInput(day)
-    const endMinute = minute + 60
-    setForm({
-      name: '',
-      isAllDay: false,
-      startDate: dateStr,
-      startTime: minuteToTime(minute),
-      endDate: dateStr,
-      // If +1h would spill past midnight, leave blank so it defaults to +1h.
-      endTime: endMinute <= 24 * 60 ? minuteToTime(endMinute) : '',
-      eventLocation: '',
-      sharingState: 'private',
-    })
-    setHoverSlot(null)
-    onOpen()
-  }
+  const [form, setForm] = useState<EventForm>(EMPTY_FORM)
 
   const teamIds = useMemo(() => teams.map((t) => t.id), [teams])
+
+  // The date range currently visible, depending on the view.
+  const [rangeStart, rangeEnd] = useMemo<[Date, Date]>(() => {
+    if (view === 'day') return [startOfDay(anchor), addDays(startOfDay(anchor), 1)]
+    if (view === 'week') return [startOfWeek(anchor), addDays(startOfWeek(anchor), 7)]
+    const grid = monthGridDays(anchor)
+    return [grid[0], addDays(grid[grid.length - 1], 1)]
+  }, [view, anchor])
 
   useEffect(() => {
     fetchEvents()
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [anchor, teams])
+  }, [rangeStart.getTime(), rangeEnd.getTime(), teamIds.join(',')])
 
-  // Keep the "current time" line fresh.
   useEffect(() => {
     const id = setInterval(() => setNow(new Date()), 60 * 1000)
     return () => clearInterval(id)
   }, [])
 
-  // Scroll to ~7:00 on first mount so the morning is in view.
-  useEffect(() => {
-    if (scrollRef.current) scrollRef.current.scrollTop = 7 * HOUR_HEIGHT - 12
-  }, [])
-
   async function fetchEvents() {
     if (!teamIds || teamIds.length === 0) return setEvents([])
     setLoading(true)
-    const wkStart = startOfWeek(anchor)
-    const wkEnd = addDays(wkStart, 7)
     try {
-      // Any event that *overlaps* the week, so multi-day / overnight events
-      // that started before this week are still picked up.
       const { data, error } = await supabase
         .from('events')
         .select('*')
         .in('teamId', teamIds)
-        .lt('startAt', wkEnd.toISOString())
-        .gt('endAt', wkStart.toISOString())
+        .lt('startAt', rangeEnd.toISOString())
+        .gt('endAt', rangeStart.toISOString())
         .order('startAt', { ascending: true })
-
       if (error) {
         console.error('fetch events error', error)
         setEvents([])
@@ -282,32 +96,83 @@ export default function CalendarTab() {
     }
   }
 
-  function prevWeek() {
-    setAnchor((a) => addDays(a, -7))
-  }
+  const visibleEvents = useMemo(
+    () => events.filter((e) => filters.has(e.sharingState as SharingState)),
+    [events, filters],
+  )
 
-  function nextWeek() {
-    setAnchor((a) => addDays(a, 7))
-  }
-
-  function goToday() {
-    setAnchor(startOfWeek(new Date()))
-  }
-
-  function days() {
+  const days = useMemo(() => {
+    if (view === 'day') return [startOfDay(anchor)]
     const start = startOfWeek(anchor)
-    return Array.from({ length: 7 }).map((_, i) => addDays(start, i))
+    return Array.from({ length: 7 }, (_, i) => addDays(start, i))
+  }, [view, anchor])
+
+  function goPrev() {
+    if (view === 'day') setAnchor((a) => addDays(a, -1))
+    else if (view === 'week') setAnchor((a) => addDays(a, -7))
+    else setAnchor((a) => addMonths(a, -1))
+  }
+  function goNext() {
+    if (view === 'day') setAnchor((a) => addDays(a, 1))
+    else if (view === 'week') setAnchor((a) => addDays(a, 7))
+    else setAnchor((a) => addMonths(a, 1))
+  }
+  function goToday() {
+    setAnchor(startOfDay(new Date()))
   }
 
-  const weekStart = startOfWeek(anchor)
-  const weekEnd = addDays(weekStart, 6)
-  const rangeLabel = `${weekStart.toLocaleDateString('ja-JP', {
-    month: 'long',
-    day: 'numeric',
-  })} – ${weekEnd.toLocaleDateString('ja-JP', {
-    month: weekStart.getMonth() === weekEnd.getMonth() ? undefined : 'long',
-    day: 'numeric',
-  })}`
+  function toggleFilter(s: SharingState) {
+    setFilters((prev) => {
+      const next = new Set(prev)
+      if (next.has(s)) next.delete(s)
+      else next.add(s)
+      return next
+    })
+  }
+
+  const rangeLabel = useMemo(() => {
+    if (view === 'day') {
+      return anchor.toLocaleDateString('ja-JP', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+        weekday: 'short',
+      })
+    }
+    if (view === 'week') {
+      const ws = startOfWeek(anchor)
+      const we = addDays(ws, 6)
+      const sameMonth = ws.getMonth() === we.getMonth()
+      return `${ws.toLocaleDateString('ja-JP', { month: 'long', day: 'numeric' })} – ${we.toLocaleDateString(
+        'ja-JP',
+        { month: sameMonth ? undefined : 'long', day: 'numeric' },
+      )}`
+    }
+    return `${anchor.getFullYear()}年 ${anchor.getMonth() + 1}月`
+  }, [view, anchor])
+
+  function openBlank() {
+    setForm(EMPTY_FORM)
+    onOpen()
+  }
+
+  function openSlot(day: Date, minute: number) {
+    const dateStr = toDateInput(day)
+    const endMinute = minute + 60
+    setForm({
+      ...EMPTY_FORM,
+      startDate: dateStr,
+      startTime: minuteToTime(minute),
+      endDate: dateStr,
+      endTime: endMinute <= 24 * 60 ? minuteToTime(endMinute) : '',
+    })
+    onOpen()
+  }
+
+  function openDayView(day: Date) {
+    setAnchor(startOfDay(day))
+    setView('day')
+  }
 
   async function handleCreate() {
     if (!user) {
@@ -327,13 +192,11 @@ export default function CalendarTab() {
     let start: Date
     let end: Date
     if (form.isAllDay) {
-      // Midnight of the start day .. midnight after the end day (half-open).
       start = new Date(`${form.startDate}T00:00`)
       const endBase = new Date(`${form.endDate || form.startDate}T00:00`)
       end = new Date(endBase.getTime() + 24 * 60 * 60 * 1000)
     } else {
       start = new Date(`${form.startDate}T${form.startTime}`)
-      // Default the end to one hour after the start when it is left blank.
       const endRaw = new Date(`${form.endDate || form.startDate}T${form.endTime}`)
       end = isNaN(endRaw.getTime()) ? new Date(start.getTime() + 60 * 60 * 1000) : endRaw
     }
@@ -350,7 +213,7 @@ export default function CalendarTab() {
       endAt: end.toISOString(),
       isAllDay: form.isAllDay,
       eventLocation: form.eventLocation || null,
-      sharingState: form.sharingState as EventRow['sharingState'],
+      sharingState: form.sharingState as SharingState,
     })
 
     if (error) {
@@ -365,540 +228,109 @@ export default function CalendarTab() {
       return
     }
 
-    setForm({
-      name: '',
-      isAllDay: false,
-      startDate: '',
-      startTime: '',
-      endDate: '',
-      endTime: '',
-      eventLocation: '',
-      sharingState: 'private',
-    })
+    setForm(EMPTY_FORM)
     onClose()
     fetchEvents()
   }
 
   async function handleDelete(id: string) {
-    try {
-      await supabase.from('events').delete().eq('id', id)
-      fetchEvents()
-    } catch (err) {
-      console.error('delete event error', err)
+    const { error } = await supabase.from('events').delete().eq('id', id)
+    if (error) {
+      toast({ status: 'error', title: '削除できませんでした', description: error.message })
+      return
     }
+    fetchEvents()
   }
 
-  const week = days()
-  const nowMinutes = minutesOfDay(now)
-
   return (
-    <Box>
-      {/* Toolbar */}
-      <Flex
-        justify="space-between"
-        align={{ base: 'stretch', md: 'center' }}
-        direction={{ base: 'column', md: 'row' }}
-        gap={3}
-        mb={5}
-      >
-        <HStack spacing={3}>
-          <HStack
-            spacing={0}
-            bg="paper-2"
-            border="1px solid"
-            borderColor="gray.200"
-            borderRadius="lg"
-            overflow="hidden"
-          >
-            <IconButton
-              aria-label="前の週"
-              icon={<ChevronLeftIcon boxSize={5} />}
-              variant="ghost"
-              borderRadius={0}
-              onClick={prevWeek}
-            />
-            <Box w="1px" h={6} bg="gray.200" />
-            <IconButton
-              aria-label="次の週"
-              icon={<ChevronRightIcon boxSize={5} />}
-              variant="ghost"
-              borderRadius={0}
-              onClick={nextWeek}
-            />
-          </HStack>
-          <Button variant="secondary" onClick={goToday}>
-            今日
-          </Button>
-          <Box>
-            <Heading size="md" letterSpacing="tight">
+    <Flex align="start" gap={0}>
+      <CalendarSidebar
+        anchor={anchor}
+        now={now}
+        onPickDate={(d) => setAnchor(startOfDay(d))}
+        onCreate={openBlank}
+        filters={filters}
+        onToggleFilter={toggleFilter}
+      />
+
+      <Box flex={1} minW={0}>
+        {/* Toolbar */}
+        <Flex
+          justify="space-between"
+          align={{ base: 'stretch', md: 'center' }}
+          direction={{ base: 'column', md: 'row' }}
+          gap={3}
+          mb={5}
+        >
+          <HStack spacing={3}>
+            <HStack
+              spacing={0}
+              bg="paper-2"
+              border="1px solid"
+              borderColor="gray.200"
+              borderRadius="lg"
+              overflow="hidden"
+            >
+              <IconButton aria-label="前へ" icon={<ChevronLeftIcon boxSize={5} />} variant="ghost" borderRadius={0} onClick={goPrev} />
+              <Box w="1px" h={6} bg="gray.200" />
+              <IconButton aria-label="次へ" icon={<ChevronRightIcon boxSize={5} />} variant="ghost" borderRadius={0} onClick={goNext} />
+            </HStack>
+            <Button variant="secondary" onClick={goToday}>
+              今日
+            </Button>
+            <Heading size="md" letterSpacing="tight" noOfLines={1}>
               {rangeLabel}
             </Heading>
-            <Text fontSize="xs" color="gray.500" fontFamily="mono">
-              {weekStart.getFullYear()}
-            </Text>
-          </Box>
-        </HStack>
+          </HStack>
 
-        <Button
-          variant="signal"
-          leftIcon={<AddIcon boxSize={3} />}
-          onClick={() => {
-            setForm({
-              name: '',
-              isAllDay: false,
-              startDate: '',
-              startTime: '',
-              endDate: '',
-              endTime: '',
-              eventLocation: '',
-              sharingState: 'private',
-            })
-            onOpen()
-          }}
-        >
-          予定を追加
-        </Button>
-      </Flex>
-
-      {loading ? (
-        <Center py={20}>
-          <Spinner color="primary.500" thickness="3px" />
-        </Center>
-      ) : (
-        <Box
-          bg="paper-2"
-          border="1px solid"
-          borderColor="gray.200"
-          borderRadius="xl"
-          overflow="hidden"
-        >
-          <Box overflowX="auto">
-            <Box minW="760px">
-              {/* Day headers */}
-              <Flex borderBottom="1px solid" borderColor="gray.200">
-                <Box w={`${GUTTER}px`} flexShrink={0} />
-                {week.map((d) => {
-                  const today = isSameDay(d, now)
-                  const dow = d.getDay()
-                  return (
-                    <VStack
-                      key={d.toISOString()}
-                      flex={1}
-                      spacing={1}
-                      py={2.5}
-                      borderLeft="1px solid"
-                      borderColor="gray.100"
-                    >
-                      <Text
-                        fontSize="xs"
-                        fontWeight="bold"
-                        color={dow === 0 ? 'danger.500' : dow === 6 ? 'primary.600' : 'gray.400'}
-                      >
-                        {WEEKDAYS[dow]}
-                      </Text>
-                      <Center
-                        boxSize={8}
-                        borderRadius="full"
-                        bg={today ? 'signal.500' : 'transparent'}
-                      >
-                        <Text
-                          fontFamily="heading"
-                          fontWeight="700"
-                          fontSize="lg"
-                          lineHeight="1"
-                          color={today ? 'white' : 'gray.900'}
-                        >
-                          {d.getDate()}
-                        </Text>
-                      </Center>
-                    </VStack>
-                  )
-                })}
-              </Flex>
-
-              {/* All-day row — only shown when there are all-day events */}
-              {events.some((e) => e.isAllDay) && (
-                <Flex borderBottom="1px solid" borderColor="gray.200" bg="gray.50">
-                  <Center w={`${GUTTER}px`} flexShrink={0} px={1}>
-                    <Text fontSize="10px" fontWeight="bold" color="gray.400" textAlign="center">
-                      終日
-                    </Text>
-                  </Center>
-                  {week.map((d) => {
-                    const allDay = events.filter((e) => e.isAllDay && overlapsDay(e, d))
-                    return (
-                      <VStack
-                        key={d.toISOString()}
-                        flex={1}
-                        spacing={1}
-                        align="stretch"
-                        p={1}
-                        minH="32px"
-                        borderLeft="1px solid"
-                        borderColor="gray.100"
-                      >
-                        {allDay.map((ev) => {
-                          const style =
-                            EVENT_STYLE[ev.sharingState as keyof typeof EVENT_STYLE] ??
-                            EVENT_STYLE.private
-                          const mine = user && ev.createdBy === user.id
-                          return (
-                            <Flex
-                              key={ev.id}
-                              role="group"
-                              align="center"
-                              justify="space-between"
-                              gap={1}
-                              bg={style.bg}
-                              borderLeft="3px solid"
-                              borderLeftColor={style.accent}
-                              borderRadius="sm"
-                              px={1.5}
-                              py={0.5}
-                            >
-                              <Text
-                                fontSize="xs"
-                                fontWeight="600"
-                                color={style.text}
-                                noOfLines={1}
-                              >
-                                {ev.name}
-                              </Text>
-                              {mine && (
-                                <IconButton
-                                  aria-label="削除"
-                                  size="xs"
-                                  minW="auto"
-                                  h="auto"
-                                  p={0.5}
-                                  variant="ghost"
-                                  color={style.time}
-                                  icon={<DeleteIcon boxSize={2.5} />}
-                                  opacity={0}
-                                  _groupHover={{ opacity: 1 }}
-                                  _hover={{ color: 'danger.500', bg: 'transparent' }}
-                                  onClick={() => handleDelete(ev.id)}
-                                />
-                              )}
-                            </Flex>
-                          )
-                        })}
-                      </VStack>
-                    )
-                  })}
-                </Flex>
-              )}
-
-              {/* Scrollable time grid */}
-              <Flex
-                ref={scrollRef}
-                overflowY="auto"
-                maxH={{ base: '60vh', md: 'calc(100vh - 300px)' }}
-                position="relative"
-              >
-                {/* Time gutter */}
-                <Box w={`${GUTTER}px`} flexShrink={0} position="relative" h={`${TOTAL_HEIGHT}px`}>
-                  {Array.from({ length: 23 }).map((_, i) => {
-                    const hour = i + 1
-                    return (
-                      <Text
-                        key={hour}
-                        position="absolute"
-                        top={`${hour * HOUR_HEIGHT}px`}
-                        right="8px"
-                        transform="translateY(-50%)"
-                        fontSize="11px"
-                        fontFamily="mono"
-                        color="gray.400"
-                      >
-                        {hour}:00
-                      </Text>
-                    )
-                  })}
-                </Box>
-
-                {/* Day columns with hour lines */}
-                <Flex
-                  flex={1}
-                  position="relative"
-                  h={`${TOTAL_HEIGHT}px`}
-                  backgroundImage={`repeating-linear-gradient(to bottom, var(--line) 0, var(--line) 1px, transparent 1px, transparent ${HOUR_HEIGHT}px)`}
-                >
-                  {week.map((d) => {
-                    const today = isSameDay(d, now)
-                    const positioned = layoutDay(d, events)
-                    const dayIso = d.toISOString()
-                    const ghostMinute = hoverSlot?.dayIso === dayIso ? hoverSlot.minute : null
-                    return (
-                      <Box
-                        key={dayIso}
-                        flex={1}
-                        position="relative"
-                        borderLeft="1px solid"
-                        borderColor="gray.100"
-                        cursor="pointer"
-                        onMouseMove={(e) => {
-                          const minute = minuteFromPointer(e)
-                          if (hoverSlot?.dayIso !== dayIso || hoverSlot.minute !== minute) {
-                            setHoverSlot({ dayIso, minute })
-                          }
-                        }}
-                        onMouseLeave={() =>
-                          setHoverSlot((s) => (s?.dayIso === dayIso ? null : s))
-                        }
-                        onClick={(e) => openSlot(d, minuteFromPointer(e))}
-                      >
-                        {/* Ghost slot following the cursor (1-hour preview, 15-min snap) */}
-                        {ghostMinute !== null && (
-                          <Box
-                            position="absolute"
-                            top={`${(ghostMinute / 60) * HOUR_HEIGHT}px`}
-                            left="2px"
-                            right="2px"
-                            height={`${Math.min(HOUR_HEIGHT, ((24 * 60 - ghostMinute) / 60) * HOUR_HEIGHT) - 2}px`}
-                            bg="primary.50"
-                            border="1px dashed"
-                            borderColor="primary.400"
-                            borderRadius="sm"
-                            px={1.5}
-                            py={0.5}
-                            pointerEvents="none"
-                            zIndex={1}
-                          >
-                            <Text fontSize="10px" fontWeight="600" color="primary.700">
-                              + {minuteToTime(ghostMinute)}
-                            </Text>
-                          </Box>
-                        )}
-
-                        {positioned.map(({ ev, start, end, fromPrev, toNext, colIndex, colCount }) => {
-                          const style =
-                            EVENT_STYLE[ev.sharingState as keyof typeof EVENT_STYLE] ??
-                            EVENT_STYLE.private
-                          const mine = user && ev.createdBy === user.id
-                          return (
-                            <Box
-                              key={ev.id}
-                              role="group"
-                              position="absolute"
-                              top={`${(start / 60) * HOUR_HEIGHT}px`}
-                              height={`${((end - start) / 60) * HOUR_HEIGHT - 2}px`}
-                              left={`calc(${(colIndex / colCount) * 100}% + 2px)`}
-                              width={`calc(${100 / colCount}% - 4px)`}
-                              bg={style.bg}
-                              borderLeft="3px solid"
-                              borderLeftColor={style.accent}
-                              borderTopRadius={fromPrev ? 'none' : 'sm'}
-                              borderBottomRadius={toNext ? 'none' : 'sm'}
-                              px={1.5}
-                              py={1}
-                              overflow="hidden"
-                              cursor="default"
-                              transition="filter 0.1s"
-                              _hover={{ filter: 'brightness(0.97)', zIndex: 2 }}
-                              onClick={(e) => e.stopPropagation()}
-                            >
-                              <Flex justify="space-between" align="start" gap={1}>
-                                <Text
-                                  fontSize="xs"
-                                  fontWeight="600"
-                                  color={style.text}
-                                  noOfLines={end - start <= 30 ? 1 : 2}
-                                  lineHeight="1.2"
-                                >
-                                  {fromPrev && '↑ '}
-                                  {ev.name}
-                                  {toNext && ' ↓'}
-                                </Text>
-                                {mine && (
-                                  <IconButton
-                                    aria-label="削除"
-                                    size="xs"
-                                    minW="auto"
-                                    h="auto"
-                                    p={0.5}
-                                    variant="ghost"
-                                    color={style.time}
-                                    icon={<DeleteIcon boxSize={2.5} />}
-                                    opacity={0}
-                                    _groupHover={{ opacity: 1 }}
-                                    _hover={{ color: 'danger.500', bg: 'transparent' }}
-                                    onClick={(e) => {
-                                      e.stopPropagation()
-                                      handleDelete(ev.id)
-                                    }}
-                                  />
-                                )}
-                              </Flex>
-                              {end - start > 30 && (
-                                <Text fontSize="10px" fontFamily="mono" color={style.time}>
-                                  {formatTime(ev.startAt)}–{formatTime(ev.endAt)}
-                                </Text>
-                              )}
-                            </Box>
-                          )
-                        })}
-
-                        {/* Current time indicator */}
-                        {today && (
-                          <Box
-                            position="absolute"
-                            left={0}
-                            right={0}
-                            top={`${(nowMinutes / 60) * HOUR_HEIGHT}px`}
-                            h="2px"
-                            bg="signal.500"
-                            zIndex={3}
-                            pointerEvents="none"
-                          >
-                            <Box
-                              position="absolute"
-                              left="-4px"
-                              top="-3px"
-                              boxSize="8px"
-                              borderRadius="full"
-                              bg="signal.500"
-                            />
-                          </Box>
-                        )}
-                      </Box>
-                    )
-                  })}
-                </Flex>
-              </Flex>
-            </Box>
-          </Box>
-        </Box>
-      )}
-
-      <Modal isOpen={isOpen} onClose={onClose} isCentered>
-        <ModalOverlay bg="blackAlpha.500" backdropFilter="blur(2px)" />
-        <ModalContent mx={4}>
-          <ModalHeader fontFamily="heading">予定を追加</ModalHeader>
-          <ModalCloseButton borderRadius="full" />
-          <ModalBody>
-            <VStack spacing={4} align="stretch">
-              <FormControl>
-                <FormLabel>タイトル</FormLabel>
-                <Input
-                  placeholder="例: チームランチ"
-                  value={form.name}
-                  onChange={(e) => setForm({ ...form, name: e.target.value })}
-                />
-              </FormControl>
-
-              <FormControl display="flex" alignItems="center" justifyContent="space-between">
-                <FormLabel mb={0} htmlFor="all-day">
-                  終日
-                </FormLabel>
-                <Switch
-                  id="all-day"
-                  colorScheme="primary"
-                  isChecked={form.isAllDay}
-                  onChange={(e) => setForm({ ...form, isAllDay: e.target.checked })}
-                />
-              </FormControl>
-
-              {/* 15-minute suggestions shared by both time fields; still free-text. */}
-              <datalist id="time-options-15">
-                {TIME_OPTIONS.map((t) => (
-                  <option key={t} value={t} />
-                ))}
-              </datalist>
-
-              <FormControl>
-                <FormLabel>開始</FormLabel>
-                <HStack spacing={2}>
-                  <ChakraInput
-                    type="date"
-                    flex="1.4"
-                    value={form.startDate}
-                    onChange={(e) => setForm({ ...form, startDate: e.target.value })}
-                  />
-                  {!form.isAllDay && (
-                    <ChakraInput
-                      type="time"
-                      step={900}
-                      list="time-options-15"
-                      placeholder="HH:MM"
-                      flex="1"
-                      value={form.startTime}
-                      onChange={(e) => setForm({ ...form, startTime: e.target.value })}
-                    />
-                  )}
-                </HStack>
-              </FormControl>
-
-              <FormControl>
-                <FormLabel>終了</FormLabel>
-                <HStack spacing={2}>
-                  <ChakraInput
-                    type="date"
-                    flex="1.4"
-                    value={form.endDate}
-                    onChange={(e) => setForm({ ...form, endDate: e.target.value })}
-                  />
-                  {!form.isAllDay && (
-                    <ChakraInput
-                      type="time"
-                      step={900}
-                      list="time-options-15"
-                      placeholder="HH:MM"
-                      flex="1"
-                      value={form.endTime}
-                      onChange={(e) => setForm({ ...form, endTime: e.target.value })}
-                    />
-                  )}
-                </HStack>
-              </FormControl>
-
-              <FormControl>
-                <FormLabel>場所</FormLabel>
-                <Textarea
-                  rows={2}
-                  placeholder="集合場所やメモ"
-                  value={form.eventLocation}
-                  onChange={(e) => setForm({ ...form, eventLocation: e.target.value })}
-                />
-              </FormControl>
-
-              <FormControl>
-                <FormLabel>
-                  公開範囲{' '}
-                  <Badge
-                    ml={1}
-                    colorScheme={SHARING[form.sharingState as keyof typeof SHARING].colorScheme}
-                    variant="subtle"
+          <HStack spacing={2}>
+            <Menu>
+              <MenuButton as={Button} variant="secondary" rightIcon={<ChevronDownIcon />}>
+                {VIEW_LABEL[view]}
+              </MenuButton>
+              <MenuList minW="120px">
+                {(Object.keys(VIEW_LABEL) as CalendarView[]).map((v) => (
+                  <MenuItem
+                    key={v}
+                    onClick={() => setView(v)}
+                    fontWeight={view === v ? '700' : '400'}
+                    color={view === v ? 'primary.600' : 'gray.700'}
                   >
-                    {SHARING[form.sharingState as keyof typeof SHARING].label}
-                  </Badge>
-                </FormLabel>
-                <Select
-                  value={form.sharingState}
-                  onChange={(e) => setForm({ ...form, sharingState: e.target.value })}
-                >
-                  <option value="private">自分のみ</option>
-                  <option value="friends">友だち</option>
-                  <option value="team">チーム</option>
-                </Select>
-              </FormControl>
-            </VStack>
-          </ModalBody>
+                    {VIEW_LABEL[v]}表示
+                  </MenuItem>
+                ))}
+              </MenuList>
+            </Menu>
+            <Button variant="signal" leftIcon={<AddIcon boxSize={3} />} onClick={openBlank}>
+              予定を追加
+            </Button>
+          </HStack>
+        </Flex>
 
-          <ModalFooter gap={2}>
-            <Button variant="ghost" onClick={onClose}>
-              キャンセル
-            </Button>
-            <Button
-              variant="signal"
-              onClick={handleCreate}
-              isDisabled={!form.name || !form.startDate || (!form.isAllDay && !form.startTime)}
-            >
-              作成する
-            </Button>
-          </ModalFooter>
-        </ModalContent>
-      </Modal>
-    </Box>
+        {loading ? (
+          <Center py={20}>
+            <Spinner color="primary.500" thickness="3px" />
+          </Center>
+        ) : view === 'month' ? (
+          <MonthView
+            anchor={anchor}
+            events={visibleEvents}
+            now={now}
+            onDayClick={openDayView}
+          />
+        ) : (
+          <TimeGridView
+            days={days}
+            events={visibleEvents}
+            now={now}
+            currentUserId={user?.id}
+            onSlotClick={openSlot}
+            onDelete={handleDelete}
+          />
+        )}
+      </Box>
+
+      <EventModal isOpen={isOpen} onClose={onClose} form={form} setForm={setForm} onSubmit={handleCreate} />
+    </Flex>
   )
 }

--- a/src/components/Calendar/EventModal.tsx
+++ b/src/components/Calendar/EventModal.tsx
@@ -1,0 +1,159 @@
+import {
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  ModalCloseButton,
+  FormControl,
+  FormLabel,
+  Select,
+  Textarea,
+  HStack,
+  VStack,
+  Badge,
+  Switch,
+  Input as ChakraInput,
+} from '@chakra-ui/react'
+import { Button } from '../ui/Button'
+import { Input } from '../ui/Input'
+import { SHARING, TIME_OPTIONS, type EventForm, type SharingState } from './calendarUtils'
+
+interface EventModalProps {
+  isOpen: boolean
+  onClose: () => void
+  form: EventForm
+  setForm: (f: EventForm) => void
+  onSubmit: () => void
+}
+
+export function EventModal({ isOpen, onClose, form, setForm, onSubmit }: EventModalProps) {
+  const sharing = SHARING[form.sharingState as SharingState] ?? SHARING.private
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} isCentered>
+      <ModalOverlay bg="blackAlpha.500" backdropFilter="blur(2px)" />
+      <ModalContent mx={4}>
+        <ModalHeader fontFamily="heading">予定を追加</ModalHeader>
+        <ModalCloseButton borderRadius="full" />
+        <ModalBody>
+          <VStack spacing={4} align="stretch">
+            <FormControl>
+              <FormLabel>タイトル</FormLabel>
+              <Input
+                placeholder="例: チームランチ"
+                value={form.name}
+                onChange={(e) => setForm({ ...form, name: e.target.value })}
+              />
+            </FormControl>
+
+            <FormControl display="flex" alignItems="center" justifyContent="space-between">
+              <FormLabel mb={0} htmlFor="all-day">
+                終日
+              </FormLabel>
+              <Switch
+                id="all-day"
+                colorScheme="primary"
+                isChecked={form.isAllDay}
+                onChange={(e) => setForm({ ...form, isAllDay: e.target.checked })}
+              />
+            </FormControl>
+
+            {/* 15-minute suggestions shared by both time fields; still free-text. */}
+            <datalist id="time-options-15">
+              {TIME_OPTIONS.map((t) => (
+                <option key={t} value={t} />
+              ))}
+            </datalist>
+
+            <FormControl>
+              <FormLabel>開始</FormLabel>
+              <HStack spacing={2}>
+                <ChakraInput
+                  type="date"
+                  flex="1.4"
+                  value={form.startDate}
+                  onChange={(e) => setForm({ ...form, startDate: e.target.value })}
+                />
+                {!form.isAllDay && (
+                  <ChakraInput
+                    type="time"
+                    step={900}
+                    list="time-options-15"
+                    placeholder="HH:MM"
+                    flex="1"
+                    value={form.startTime}
+                    onChange={(e) => setForm({ ...form, startTime: e.target.value })}
+                  />
+                )}
+              </HStack>
+            </FormControl>
+
+            <FormControl>
+              <FormLabel>終了</FormLabel>
+              <HStack spacing={2}>
+                <ChakraInput
+                  type="date"
+                  flex="1.4"
+                  value={form.endDate}
+                  onChange={(e) => setForm({ ...form, endDate: e.target.value })}
+                />
+                {!form.isAllDay && (
+                  <ChakraInput
+                    type="time"
+                    step={900}
+                    list="time-options-15"
+                    placeholder="HH:MM"
+                    flex="1"
+                    value={form.endTime}
+                    onChange={(e) => setForm({ ...form, endTime: e.target.value })}
+                  />
+                )}
+              </HStack>
+            </FormControl>
+
+            <FormControl>
+              <FormLabel>場所</FormLabel>
+              <Textarea
+                rows={2}
+                placeholder="集合場所やメモ"
+                value={form.eventLocation}
+                onChange={(e) => setForm({ ...form, eventLocation: e.target.value })}
+              />
+            </FormControl>
+
+            <FormControl>
+              <FormLabel>
+                公開範囲{' '}
+                <Badge ml={1} colorScheme={sharing.colorScheme} variant="subtle">
+                  {sharing.label}
+                </Badge>
+              </FormLabel>
+              <Select
+                value={form.sharingState}
+                onChange={(e) => setForm({ ...form, sharingState: e.target.value })}
+              >
+                <option value="private">自分のみ</option>
+                <option value="friends">友だち</option>
+                <option value="team">チーム</option>
+              </Select>
+            </FormControl>
+          </VStack>
+        </ModalBody>
+
+        <ModalFooter gap={2}>
+          <Button variant="ghost" onClick={onClose}>
+            キャンセル
+          </Button>
+          <Button
+            variant="signal"
+            onClick={onSubmit}
+            isDisabled={!form.name || !form.startDate || (!form.isAllDay && !form.startTime)}
+          >
+            作成する
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  )
+}

--- a/src/components/Calendar/MonthView.tsx
+++ b/src/components/Calendar/MonthView.tsx
@@ -1,0 +1,140 @@
+import { Box, Grid, Flex, Text, VStack, Center } from '@chakra-ui/react'
+import {
+  WEEKDAYS,
+  EVENT_STYLE,
+  isSameDay,
+  isSameMonth,
+  monthGridDays,
+  overlapsDay,
+  formatTime,
+  type EventRow,
+  type SharingState,
+} from './calendarUtils'
+
+interface MonthViewProps {
+  anchor: Date
+  events: EventRow[]
+  now: Date
+  onDayClick: (day: Date) => void
+}
+
+const MAX_CHIPS = 3
+
+export function MonthView({ anchor, events, now, onDayClick }: MonthViewProps) {
+  const days = monthGridDays(anchor)
+
+  return (
+    <Box bg="paper-2" border="1px solid" borderColor="gray.200" borderRadius="xl" overflow="hidden">
+      {/* Weekday header */}
+      <Grid templateColumns="repeat(7, 1fr)" borderBottom="1px solid" borderColor="gray.200">
+        {WEEKDAYS.map((w, i) => (
+          <Center key={w} py={2}>
+            <Text
+              fontSize="xs"
+              fontWeight="bold"
+              color={i === 0 ? 'danger.500' : i === 6 ? 'primary.600' : 'gray.400'}
+            >
+              {w}
+            </Text>
+          </Center>
+        ))}
+      </Grid>
+
+      {/* 6-week grid */}
+      <Grid templateColumns="repeat(7, 1fr)" templateRows="repeat(6, 1fr)" h={{ base: 'auto', md: 'calc(100vh - 280px)' }}>
+        {days.map((d) => {
+          const inMonth = isSameMonth(d, anchor)
+          const today = isSameDay(d, now)
+          const dow = d.getDay()
+          const dayEvents = events
+            .filter((e) => overlapsDay(e, d))
+            .sort((a, b) => {
+              // all-day first, then by start time
+              if (a.isAllDay !== b.isAllDay) return a.isAllDay ? -1 : 1
+              return new Date(a.startAt).getTime() - new Date(b.startAt).getTime()
+            })
+          const shown = dayEvents.slice(0, MAX_CHIPS)
+          const extra = dayEvents.length - shown.length
+
+          return (
+            <Box
+              key={d.toISOString()}
+              borderRight="1px solid"
+              borderBottom="1px solid"
+              borderColor="gray.100"
+              bg={inMonth ? 'transparent' : 'gray.50'}
+              p={1.5}
+              minH={{ base: '90px', md: 0 }}
+              overflow="hidden"
+              cursor="pointer"
+              transition="background 0.1s"
+              _hover={{ bg: inMonth ? 'gray.50' : 'gray.100' }}
+              onClick={() => onDayClick(d)}
+            >
+              <Flex justify="center" mb={1}>
+                <Center
+                  boxSize={6}
+                  borderRadius="full"
+                  bg={today ? 'signal.500' : 'transparent'}
+                >
+                  <Text
+                    fontSize="sm"
+                    fontWeight={today ? '700' : '600'}
+                    color={
+                      today
+                        ? 'white'
+                        : !inMonth
+                          ? 'gray.400'
+                          : dow === 0
+                            ? 'danger.500'
+                            : dow === 6
+                              ? 'primary.600'
+                              : 'gray.700'
+                    }
+                  >
+                    {d.getDate()}
+                  </Text>
+                </Center>
+              </Flex>
+
+              <VStack spacing="2px" align="stretch">
+                {shown.map((ev) => {
+                  const style = EVENT_STYLE[ev.sharingState as SharingState] ?? EVENT_STYLE.private
+                  return (
+                    <Flex
+                      key={ev.id}
+                      align="center"
+                      gap={1}
+                      bg={ev.isAllDay ? style.bg : 'transparent'}
+                      borderRadius="sm"
+                      px={1}
+                      h="18px"
+                      overflow="hidden"
+                    >
+                      {!ev.isAllDay && (
+                        <Box boxSize="6px" borderRadius="full" bg={style.dot} flexShrink={0} />
+                      )}
+                      {!ev.isAllDay && (
+                        <Text fontSize="10px" fontFamily="mono" color="gray.500" flexShrink={0}>
+                          {formatTime(ev.startAt)}
+                        </Text>
+                      )}
+                      <Text fontSize="11px" fontWeight="500" color={style.text} noOfLines={1}>
+                        {ev.name}
+                      </Text>
+                    </Flex>
+                  )
+                })}
+                {extra > 0 && (
+                  <Text fontSize="10px" color="gray.500" pl={1}>
+                    他 {extra} 件
+                  </Text>
+                )}
+              </VStack>
+            </Box>
+          )
+        })}
+      </Grid>
+    </Box>
+  )
+}

--- a/src/components/Calendar/TimeGridView.tsx
+++ b/src/components/Calendar/TimeGridView.tsx
@@ -1,0 +1,340 @@
+import { useEffect, useRef, useState } from 'react'
+import { Box, Flex, Text, VStack, Center, IconButton } from '@chakra-ui/react'
+import { DeleteIcon } from '@chakra-ui/icons'
+import {
+  WEEKDAYS,
+  HOUR_HEIGHT,
+  GUTTER,
+  TOTAL_HEIGHT,
+  EVENT_STYLE,
+  isSameDay,
+  layoutDay,
+  minutesOfDay,
+  minuteToTime,
+  overlapsDay,
+  formatTime,
+  type EventRow,
+  type SharingState,
+} from './calendarUtils'
+
+interface TimeGridViewProps {
+  days: Date[]
+  events: EventRow[]
+  now: Date
+  currentUserId: string | undefined
+  onSlotClick: (day: Date, minute: number) => void
+  onDelete: (id: string) => void
+}
+
+export function TimeGridView({
+  days,
+  events,
+  now,
+  currentUserId,
+  onSlotClick,
+  onDelete,
+}: TimeGridViewProps) {
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const [hoverSlot, setHoverSlot] = useState<{ dayIso: string; minute: number } | null>(null)
+
+  // Scroll to ~7:00 on mount so the morning is in view.
+  useEffect(() => {
+    if (scrollRef.current) scrollRef.current.scrollTop = 7 * HOUR_HEIGHT - 12
+  }, [])
+
+  function minuteFromPointer(e: React.MouseEvent<HTMLDivElement>) {
+    const rect = e.currentTarget.getBoundingClientRect()
+    const y = e.clientY - rect.top
+    const snapped = Math.floor(((y / HOUR_HEIGHT) * 60) / 15) * 15
+    return Math.max(0, Math.min(23 * 60 + 45, snapped))
+  }
+
+  const hasAllDay = events.some((e) => e.isAllDay)
+  const minColWidth = days.length === 1 ? 'auto' : '100px'
+
+  return (
+    <Box bg="paper-2" border="1px solid" borderColor="gray.200" borderRadius="xl" overflow="hidden">
+      <Box overflowX="auto">
+        <Box minW={days.length === 1 ? 'auto' : '760px'}>
+          {/* Day headers */}
+          <Flex borderBottom="1px solid" borderColor="gray.200">
+            <Box w={`${GUTTER}px`} flexShrink={0} />
+            {days.map((d) => {
+              const today = isSameDay(d, now)
+              const dow = d.getDay()
+              return (
+                <VStack
+                  key={d.toISOString()}
+                  flex={1}
+                  minW={minColWidth}
+                  spacing={1}
+                  py={2.5}
+                  borderLeft="1px solid"
+                  borderColor="gray.100"
+                >
+                  <Text
+                    fontSize="xs"
+                    fontWeight="bold"
+                    color={dow === 0 ? 'danger.500' : dow === 6 ? 'primary.600' : 'gray.400'}
+                  >
+                    {WEEKDAYS[dow]}
+                  </Text>
+                  <Center boxSize={8} borderRadius="full" bg={today ? 'signal.500' : 'transparent'}>
+                    <Text
+                      fontFamily="heading"
+                      fontWeight="700"
+                      fontSize="lg"
+                      lineHeight="1"
+                      color={today ? 'white' : 'gray.900'}
+                    >
+                      {d.getDate()}
+                    </Text>
+                  </Center>
+                </VStack>
+              )
+            })}
+          </Flex>
+
+          {/* All-day row */}
+          {hasAllDay && (
+            <Flex borderBottom="1px solid" borderColor="gray.200" bg="gray.50">
+              <Center w={`${GUTTER}px`} flexShrink={0} px={1}>
+                <Text fontSize="10px" fontWeight="bold" color="gray.400">
+                  終日
+                </Text>
+              </Center>
+              {days.map((d) => {
+                const allDay = events.filter((e) => e.isAllDay && overlapsDay(e, d))
+                return (
+                  <VStack
+                    key={d.toISOString()}
+                    flex={1}
+                    minW={minColWidth}
+                    spacing={1}
+                    align="stretch"
+                    p={1}
+                    minH="32px"
+                    borderLeft="1px solid"
+                    borderColor="gray.100"
+                  >
+                    {allDay.map((ev) => {
+                      const style = EVENT_STYLE[ev.sharingState as SharingState] ?? EVENT_STYLE.private
+                      const mine = currentUserId && ev.createdBy === currentUserId
+                      return (
+                        <Flex
+                          key={ev.id}
+                          role="group"
+                          align="center"
+                          justify="space-between"
+                          gap={1}
+                          bg={style.bg}
+                          borderLeft="3px solid"
+                          borderLeftColor={style.accent}
+                          borderRadius="sm"
+                          px={1.5}
+                          py={0.5}
+                        >
+                          <Text fontSize="xs" fontWeight="600" color={style.text} noOfLines={1}>
+                            {ev.name}
+                          </Text>
+                          {mine && (
+                            <IconButton
+                              aria-label="削除"
+                              size="xs"
+                              minW="auto"
+                              h="auto"
+                              p={0.5}
+                              variant="ghost"
+                              color={style.time}
+                              icon={<DeleteIcon boxSize={2.5} />}
+                              opacity={0}
+                              _groupHover={{ opacity: 1 }}
+                              _hover={{ color: 'danger.500', bg: 'transparent' }}
+                              onClick={() => onDelete(ev.id)}
+                            />
+                          )}
+                        </Flex>
+                      )
+                    })}
+                  </VStack>
+                )
+              })}
+            </Flex>
+          )}
+
+          {/* Scrollable time grid */}
+          <Flex
+            ref={scrollRef}
+            overflowY="auto"
+            maxH={{ base: '60vh', md: 'calc(100vh - 320px)' }}
+            position="relative"
+          >
+            <Box w={`${GUTTER}px`} flexShrink={0} position="relative" h={`${TOTAL_HEIGHT}px`}>
+              {Array.from({ length: 23 }).map((_, i) => {
+                const hour = i + 1
+                return (
+                  <Text
+                    key={hour}
+                    position="absolute"
+                    top={`${hour * HOUR_HEIGHT}px`}
+                    right="8px"
+                    transform="translateY(-50%)"
+                    fontSize="11px"
+                    fontFamily="mono"
+                    color="gray.400"
+                  >
+                    {hour}:00
+                  </Text>
+                )
+              })}
+            </Box>
+
+            <Flex
+              flex={1}
+              position="relative"
+              h={`${TOTAL_HEIGHT}px`}
+              backgroundImage={`repeating-linear-gradient(to bottom, var(--line) 0, var(--line) 1px, transparent 1px, transparent ${HOUR_HEIGHT}px)`}
+            >
+              {days.map((d) => {
+                const today = isSameDay(d, now)
+                const positioned = layoutDay(d, events)
+                const dayIso = d.toISOString()
+                const ghostMinute = hoverSlot?.dayIso === dayIso ? hoverSlot.minute : null
+                const nowMinutes = minutesOfDay(now)
+                return (
+                  <Box
+                    key={dayIso}
+                    flex={1}
+                    minW={minColWidth}
+                    position="relative"
+                    borderLeft="1px solid"
+                    borderColor="gray.100"
+                    cursor="pointer"
+                    onMouseMove={(e) => {
+                      const minute = minuteFromPointer(e)
+                      if (hoverSlot?.dayIso !== dayIso || hoverSlot.minute !== minute) {
+                        setHoverSlot({ dayIso, minute })
+                      }
+                    }}
+                    onMouseLeave={() => setHoverSlot((s) => (s?.dayIso === dayIso ? null : s))}
+                    onClick={(e) => onSlotClick(d, minuteFromPointer(e))}
+                  >
+                    {ghostMinute !== null && (
+                      <Box
+                        position="absolute"
+                        top={`${(ghostMinute / 60) * HOUR_HEIGHT}px`}
+                        left="2px"
+                        right="2px"
+                        height={`${Math.min(HOUR_HEIGHT, ((24 * 60 - ghostMinute) / 60) * HOUR_HEIGHT) - 2}px`}
+                        bg="primary.50"
+                        border="1px dashed"
+                        borderColor="primary.400"
+                        borderRadius="sm"
+                        px={1.5}
+                        py={0.5}
+                        pointerEvents="none"
+                        zIndex={1}
+                      >
+                        <Text fontSize="10px" fontWeight="600" color="primary.700">
+                          + {minuteToTime(ghostMinute)}
+                        </Text>
+                      </Box>
+                    )}
+
+                    {positioned.map(({ ev, start, end, fromPrev, toNext, colIndex, colCount }) => {
+                      const style = EVENT_STYLE[ev.sharingState as SharingState] ?? EVENT_STYLE.private
+                      const mine = currentUserId && ev.createdBy === currentUserId
+                      return (
+                        <Box
+                          key={ev.id}
+                          role="group"
+                          position="absolute"
+                          top={`${(start / 60) * HOUR_HEIGHT}px`}
+                          height={`${((end - start) / 60) * HOUR_HEIGHT - 2}px`}
+                          left={`calc(${(colIndex / colCount) * 100}% + 2px)`}
+                          width={`calc(${100 / colCount}% - 4px)`}
+                          bg={style.bg}
+                          borderLeft="3px solid"
+                          borderLeftColor={style.accent}
+                          borderTopRadius={fromPrev ? 'none' : 'sm'}
+                          borderBottomRadius={toNext ? 'none' : 'sm'}
+                          px={1.5}
+                          py={1}
+                          overflow="hidden"
+                          cursor="default"
+                          transition="filter 0.1s"
+                          _hover={{ filter: 'brightness(0.97)', zIndex: 2 }}
+                          onClick={(e) => e.stopPropagation()}
+                        >
+                          <Flex justify="space-between" align="start" gap={1}>
+                            <Text
+                              fontSize="xs"
+                              fontWeight="600"
+                              color={style.text}
+                              noOfLines={end - start <= 30 ? 1 : 2}
+                              lineHeight="1.2"
+                            >
+                              {fromPrev && '↑ '}
+                              {ev.name}
+                              {toNext && ' ↓'}
+                            </Text>
+                            {mine && (
+                              <IconButton
+                                aria-label="削除"
+                                size="xs"
+                                minW="auto"
+                                h="auto"
+                                p={0.5}
+                                variant="ghost"
+                                color={style.time}
+                                icon={<DeleteIcon boxSize={2.5} />}
+                                opacity={0}
+                                _groupHover={{ opacity: 1 }}
+                                _hover={{ color: 'danger.500', bg: 'transparent' }}
+                                onClick={(e) => {
+                                  e.stopPropagation()
+                                  onDelete(ev.id)
+                                }}
+                              />
+                            )}
+                          </Flex>
+                          {end - start > 30 && (
+                            <Text fontSize="10px" fontFamily="mono" color={style.time}>
+                              {formatTime(ev.startAt)}–{formatTime(ev.endAt)}
+                            </Text>
+                          )}
+                        </Box>
+                      )
+                    })}
+
+                    {today && (
+                      <Box
+                        position="absolute"
+                        left={0}
+                        right={0}
+                        top={`${(nowMinutes / 60) * HOUR_HEIGHT}px`}
+                        h="2px"
+                        bg="signal.500"
+                        zIndex={3}
+                        pointerEvents="none"
+                      >
+                        <Box
+                          position="absolute"
+                          left="-4px"
+                          top="-3px"
+                          boxSize="8px"
+                          borderRadius="full"
+                          bg="signal.500"
+                        />
+                      </Box>
+                    )}
+                  </Box>
+                )
+              })}
+            </Flex>
+          </Flex>
+        </Box>
+      </Box>
+    </Box>
+  )
+}

--- a/src/components/Calendar/calendarUtils.ts
+++ b/src/components/Calendar/calendarUtils.ts
@@ -1,0 +1,198 @@
+import type { Database } from '../../types/database'
+
+export type EventRow = Database['public']['Tables']['events']['Row']
+export type SharingState = EventRow['sharingState']
+export type CalendarView = 'day' | 'week' | 'month'
+
+export const WEEKDAYS = ['日', '月', '火', '水', '木', '金', '土']
+
+export const HOUR_HEIGHT = 48 // px per hour in the time grid
+export const GUTTER = 56 // px — time-labels column
+export const TOTAL_HEIGHT = HOUR_HEIGHT * 24
+
+export const SHARING: Record<SharingState, { label: string; colorScheme: string }> = {
+  private: { label: '自分のみ', colorScheme: 'gray' },
+  friends: { label: '友だち', colorScheme: 'primary' },
+  team: { label: 'チーム', colorScheme: 'signal' },
+}
+
+// Event block colors per sharing state, aligned with the design system.
+export const EVENT_STYLE: Record<
+  SharingState,
+  { bg: string; accent: string; text: string; time: string; dot: string }
+> = {
+  private: { bg: 'gray.100', accent: 'gray.400', text: 'gray.700', time: 'gray.500', dot: 'gray.400' },
+  friends: { bg: 'primary.50', accent: 'primary.500', text: 'primary.800', time: 'primary.600', dot: 'primary.500' },
+  team: { bg: 'signal.50', accent: 'signal.500', text: 'signal.800', time: 'signal.600', dot: 'signal.500' },
+}
+
+// 15-minute time options: "00:00", "00:15", … "23:45".
+export const TIME_OPTIONS = Array.from({ length: 96 }, (_, i) => {
+  const h = Math.floor(i / 4)
+  const m = (i % 4) * 15
+  return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`
+})
+
+export function startOfWeek(d: Date) {
+  const dt = new Date(d)
+  const day = dt.getDay()
+  dt.setHours(0, 0, 0, 0)
+  dt.setDate(dt.getDate() - day)
+  return dt
+}
+
+export function startOfDay(d: Date) {
+  const dt = new Date(d)
+  dt.setHours(0, 0, 0, 0)
+  return dt
+}
+
+export function addDays(d: Date, days: number) {
+  const dt = new Date(d)
+  dt.setDate(dt.getDate() + days)
+  return dt
+}
+
+export function addMonths(d: Date, months: number) {
+  const dt = new Date(d)
+  dt.setMonth(dt.getMonth() + months)
+  return dt
+}
+
+export function isSameDay(a: Date, b: Date) {
+  return (
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate()
+  )
+}
+
+export function isSameMonth(a: Date, b: Date) {
+  return a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth()
+}
+
+export function minutesOfDay(d: Date) {
+  return d.getHours() * 60 + d.getMinutes()
+}
+
+// Local "YYYY-MM-DD" for date inputs (avoids the UTC shift of toISOString).
+export function toDateInput(d: Date) {
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const dd = String(d.getDate()).padStart(2, '0')
+  return `${y}-${m}-${dd}`
+}
+
+// minutes-from-midnight → "HH:MM"
+export function minuteToTime(min: number) {
+  const h = Math.floor(min / 60)
+  const m = min % 60
+  return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`
+}
+
+export function formatTime(iso: string) {
+  return new Date(iso).toLocaleTimeString('ja-JP', { hour: '2-digit', minute: '2-digit' })
+}
+
+// Does the event's [start, end) range touch the given calendar day?
+export function overlapsDay(ev: EventRow, day: Date) {
+  const ds = startOfDay(day)
+  const de = addDays(ds, 1)
+  return new Date(ev.startAt) < de && new Date(ev.endAt) > ds
+}
+
+// The 6-week (42-cell) grid that contains the month of `anchor`.
+export function monthGridDays(anchor: Date) {
+  const first = new Date(anchor.getFullYear(), anchor.getMonth(), 1)
+  const gridStart = startOfWeek(first)
+  return Array.from({ length: 42 }, (_, i) => addDays(gridStart, i))
+}
+
+export interface EventForm {
+  name: string
+  isAllDay: boolean
+  startDate: string
+  startTime: string
+  endDate: string
+  endTime: string
+  eventLocation: string
+  sharingState: string
+}
+
+export const EMPTY_FORM: EventForm = {
+  name: '',
+  isAllDay: false,
+  startDate: '',
+  startTime: '',
+  endDate: '',
+  endTime: '',
+  eventLocation: '',
+  sharingState: 'private',
+}
+
+export type Positioned = {
+  ev: EventRow
+  start: number // minutes from midnight (clamped to this day)
+  end: number
+  fromPrev: boolean // event began on an earlier day
+  toNext: boolean // event continues into a later day
+  colIndex: number
+  colCount: number
+}
+
+/**
+ * Pack one day's events into side-by-side columns, Google-Calendar style.
+ * Each event is sliced to the portion that falls on `day`, so multi-day and
+ * overnight events appear on every day they cover (clamped to midnight bounds).
+ */
+export function layoutDay(day: Date, allEvents: EventRow[]): Positioned[] {
+  const dayStart = startOfDay(day)
+  const dayEnd = addDays(dayStart, 1)
+
+  const items = allEvents
+    .map((ev) => {
+      if (ev.isAllDay) return null // all-day events live in their own row
+      const s = new Date(ev.startAt)
+      const e = new Date(ev.endAt)
+      if (!(s < dayEnd && e > dayStart)) return null
+      const start = s <= dayStart ? 0 : minutesOfDay(s)
+      const rawEnd = e >= dayEnd ? 24 * 60 : minutesOfDay(e)
+      const end = Math.min(Math.max(rawEnd, start + 20), 24 * 60)
+      return { ev, start, end, fromPrev: s < dayStart, toNext: e > dayEnd }
+    })
+    .filter((x): x is NonNullable<typeof x> => x !== null)
+    .sort((a, b) => a.start - b.start || a.end - b.end)
+
+  const result: Positioned[] = []
+  let cluster: typeof items = []
+  let clusterEnd = -1
+
+  const flush = () => {
+    const colEnds: number[] = []
+    const colOf = new Map<EventRow, number>()
+    for (const it of cluster) {
+      let col = colEnds.findIndex((end) => it.start >= end)
+      if (col === -1) {
+        col = colEnds.length
+        colEnds.push(it.end)
+      } else {
+        colEnds[col] = it.end
+      }
+      colOf.set(it.ev, col)
+    }
+    const colCount = colEnds.length
+    for (const it of cluster) {
+      result.push({ ...it, colIndex: colOf.get(it.ev)!, colCount })
+    }
+    cluster = []
+    clusterEnd = -1
+  }
+
+  for (const it of items) {
+    if (cluster.length && it.start >= clusterEnd) flush()
+    cluster.push(it)
+    clusterEnd = Math.max(clusterEnd, it.end)
+  }
+  if (cluster.length) flush()
+  return result
+}

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,3 +1,4 @@
+import { forwardRef } from 'react'
 import { Button as ChakraButton, type ButtonProps as ChakraButtonProps } from '@chakra-ui/react'
 
 type Variant = 'primary' | 'signal' | 'secondary' | 'ghost'
@@ -6,6 +7,11 @@ interface ButtonProps extends Omit<ChakraButtonProps, 'variant'> {
   variant?: Variant
 }
 
-export function Button({ variant = 'primary', ...props }: ButtonProps) {
-  return <ChakraButton variant={variant} {...props} />
-}
+// forwardRef so the component works correctly as a Chakra `as` target
+// (Menu/Tooltip/Popover triggers need the ref to size and position).
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
+  { variant = 'primary', ...props },
+  ref,
+) {
+  return <ChakraButton ref={ref} variant={variant} {...props} />
+})


### PR DESCRIPTION
## 概要
Google カレンダーを参考に、カレンダーを **日 / 週 / 月** の3ビューに対応し、**ビューセレクタ**と**サイドバー（ミニカレンダー＋カレンダー選択）**を追加しました。

> ⚠️ このPRは #24（`feature/calendar-slot-quick-add`）を土台にしたスタックPRです。差分をカレンダービュー作業に絞るため base を #24 のブランチにしています。#24 をマージ後、base を main に切り替えるか、まとめてマージしてください。

## 変更点
- **calendarUtils.ts**: 定数・日付ヘルパー・`layoutDay`・型を集約（重複排除）
- **TimeGridView.tsx**: 日(1列)・週(7列)で共通のタイムグリッド。終日行／現在時刻ライン／15分スナップのスロット追加（ホバーゴースト→クリック追加）
- **MonthView.tsx**: 6週間の月グリッド。終日は帯、時刻ありはドット＋時刻、入りきらない分は「他N件」。日付クリックでその日の**日表示にドリルダウン**
- **CalendarSidebar.tsx**: 「作成」ボタン／ミニ月カレンダー（クリックで日付移動）／「マイカレンダー」= 公開範囲(自分のみ/友だち/チーム)の表示フィルタ
- **EventModal.tsx**: 予定フォームを独立コンポーネント化（親が `form` を制御）
- **CalendarTab.tsx**: ビュー切替・期間ナビ（日±1/週±7/月±1）・ビューセレクタ・**表示中の期間に応じたイベント取得**を行うコンテナに再構成

## 動作
- 右上の「週 ▼」セレクタで 日/週/月 を切替
- サイドバーのミニカレンダーで日付ジャンプ、チェックで公開範囲フィルタ
- 月表示の日付クリック → その日の日表示へ

## 補足
- サイドバーは `lg` 未満では非表示（モバイルはツールバーの「予定を追加」で対応）
- マイグレーション `0002_event_all_day.sql`（`isAllDay`）が引き続き必要

🤖 Generated with [Claude Code](https://claude.com/claude-code)