### PR TITLE
feat: マップ機能強化（レイヤー切替・手動更新・現在地復帰）+ カレンダー/Cartographデザイン取り込み

### DIFF
--- a/src/components/Map/MapTab.tsx
+++ b/src/components/Map/MapTab.tsx
@@ -31,6 +31,8 @@ const TILE_LAYERS = {
 
 type TileLayerKey = keyof typeof TILE_LAYERS
 
+const DEFAULT_ZOOM = 13
+
 function RecenterMap({ position }: { position: LatLng | null }) {
   const map = useMap()
   const centered = useRef(false)
@@ -63,7 +65,7 @@ function TripleClickRecenter({ position }: { position: LatLng | null }) {
       if (timer.current) clearTimeout(timer.current)
       timer.current = setTimeout(() => { clickCount.current = 0 }, 500)
       if (clickCount.current >= 2 && position) {
-        map.setView([position.lat, position.lng], map.getZoom())
+        map.setView([position.lat, position.lng], DEFAULT_ZOOM)
         clickCount.current = 0
       }
     },
@@ -231,7 +233,7 @@ export default function MapTab() {
         </HStack>
         <MapContainer
           center={currentPosition ? [currentPosition.lat, currentPosition.lng] : [35.6762, 139.6503]}
-          zoom={13}
+          zoom={DEFAULT_ZOOM}
           doubleClickZoom={false}
           style={{ height: '100%', width: '100%' }}
         >


### PR DESCRIPTION
## 概要
`feature/newversion` に加えた変更をまとめた PR です。マップ機能の強化と、カレンダー機能・Cartograph デザインの取り込みを行いました。

## 変更内容

### マップ (MapTab)
- 位置共有をリアルタイム購読から**ボタン更新方式**に変更（`fetchLocations()` を手動実行）
- タブ表示時に位置情報を**自動取得**（起動時はボタン操作不要）
- **地図 / 航空写真 / 公共交通**のタイルレイヤー切替ボタンを追加
- 初回取得時のみ現在地にセンタリング（以降は自由スクロール）
- **ダブルクリックで現在地に復帰**（dblclick ズームは無効化して干渉を解消）
- 現在地復帰時にデフォルトズーム倍率へリセット

### カレンダー / デザイン
- `feature/cartograph-redesign` から CalendarTab（週表示タイムライン + インラインモーダル + 終日対応）を取り込み
- EventModal を CalendarTab に統合
- `events` テーブルに `all_day` フィールド追加（migration `0002_event_all_day.sql`）
- Cartograph デザイントークン（theme / index.css / Button）を適用
- `MainLayout` の Tabs に `isLazy` を追加しマップ初期描画問題を解消

## 確認
- [x] `npm run build` が通る
- [ ] 動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)