### PR TITLE
fix/feat: カレンダー整備（ボタン高さ・今日カード・列ズレ・終日追加 ほか）

### DIFF
--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -153,9 +153,11 @@ const theme = extendTheme({
         _focusVisible: { boxShadow: 'focus' },
       },
       sizes: {
-        sm: { h: 9, minW: 9, fontSize: 'sm', px: 4 },
-        md: { h: 11, minW: 11, fontSize: 'md', px: 6 },
-        lg: { h: 13, minW: 13, fontSize: 'lg', px: 8 },
+        // NOTE: use rem strings, not 9/11/13 — those keys don't exist in
+        // Chakra's spacing scale (…8,10,12,14…), so `h: 11` renders as 11px.
+        sm: { h: '2.25rem', minW: '2.25rem', fontSize: 'sm', px: 4 },
+        md: { h: '2.75rem', minW: '2.75rem', fontSize: 'md', px: 6 },
+        lg: { h: '3.25rem', minW: '3.25rem', fontSize: 'lg', px: 8 },
       },
       variants: {
         // Brand action — ocean teal


### PR DESCRIPTION
## 概要
カレンダーまわりの不具合修正と UX 改善をまとめた PR です。

## 含まれる変更
1. **ボタン高さ潰れの修正**: テーマの `Button.sizes` で `h:9/11/13` を指定していたが Chakra のスペーシングスケールに無いキーで `11px` 等の生pxとして適用され、全ボタンが潰れて文字がはみ出していた → rem 指定に変更（md=44px）。プレビューで実測確認済み。
2. **サイドバーに常時表示の「今日」カード**: ミニ月カレンダーが別の月でも today が分かるよう、日付バッジ＋曜日付き日付を常時表示。クリックで今日へジャンプ＆ミニカレンダーを今月へ。ミニカレンダーの today に枠線も追加。
3. **ツールバーの「予定を追加」ボタンを削除**: サイドバーの「作成」とグリッドのスロットクリックで追加できるため不要に。
4. **スクロールバーによる列ズレを修正**: 日付ヘッダーとタイムグリッドを1つのスクロール領域にまとめ、ヘッダー(＋終日行)を sticky 化。同一幅・同一スクロールバーで列が揃い、スクロール中もヘッダー固定。
5. **終日行クリックで終日予定を追加**: 「終日」セルをクリックでその日付の終日プリフィルモーダルを表示。空の日でも追加できるよう終日行を常時表示に。

## 確認
- ビルド・Lint クリーン
- ログイン画面のボタンはプレビューで 11px→44px を実測確認（カレンダー内は要ログインのため目視は dev で）

🤖 Generated with [Claude Code](https://claude.com/claude-code)