### PR TITLE
feat: 終日のクリック追加・サイドバー今日カード・列ズレ修正・予定追加ボタン削除

### DIFF
--- a/src/components/Calendar/CalendarSidebar.tsx
+++ b/src/components/Calendar/CalendarSidebar.tsx
@@ -33,17 +33,67 @@ export function CalendarSidebar({
   const [miniMonth, setMiniMonth] = useState(() => new Date(anchor))
   const days = monthGridDays(miniMonth)
 
+  // Jump the whole calendar to today and bring the mini calendar back to it.
+  function goToday() {
+    onPickDate(now)
+    setMiniMonth(new Date(now))
+  }
+
   return (
     <Box w="260px" flexShrink={0} display={{ base: 'none', lg: 'block' }} pr={6}>
       <Button
         variant="signal"
         leftIcon={<AddIcon boxSize={3} />}
         onClick={onCreate}
-        mb={6}
+        mb={4}
         boxShadow="md"
       >
         作成
       </Button>
+
+      {/* Always-visible "today" card — jumps to today on click */}
+      <Flex
+        as="button"
+        type="button"
+        onClick={goToday}
+        align="center"
+        gap={3}
+        w="full"
+        mb={6}
+        p={2.5}
+        borderRadius="xl"
+        border="1px solid"
+        borderColor="gray.200"
+        bg="paper-2"
+        textAlign="left"
+        transition="all 0.15s"
+        _hover={{ borderColor: 'signal.300', bg: 'signal.50' }}
+      >
+        <Center
+          boxSize={12}
+          flexShrink={0}
+          flexDirection="column"
+          lineHeight="1"
+          borderRadius="lg"
+          bg="signal.500"
+          color="white"
+        >
+          <Text fontSize="9px" fontWeight="bold">
+            {now.getMonth() + 1}月
+          </Text>
+          <Text fontFamily="heading" fontWeight="700" fontSize="lg">
+            {now.getDate()}
+          </Text>
+        </Center>
+        <Box>
+          <Text fontSize="xs" color="gray.500">
+            今日
+          </Text>
+          <Text fontSize="sm" fontWeight="600" color="gray.900">
+            {now.toLocaleDateString('ja-JP', { month: 'long', day: 'numeric', weekday: 'short' })}
+          </Text>
+        </Box>
+      </Flex>
 
       {/* Mini month calendar */}
       <Box mb={6}>
@@ -93,6 +143,8 @@ export function CalendarSidebar({
                     selected ? 'white' : today ? 'signal.600' : inMonth ? 'gray.700' : 'gray.300'
                   }
                   bg={selected ? 'primary.500' : 'transparent'}
+                  border={today && !selected ? '1.5px solid' : '1.5px solid transparent'}
+                  borderColor={today && !selected ? 'signal.400' : 'transparent'}
                   _hover={{ bg: selected ? 'primary.600' : 'gray.100' }}
                   onClick={() => onPickDate(d)}
                 >

--- a/src/components/Calendar/CalendarTab.tsx
+++ b/src/components/Calendar/CalendarTab.tsx
@@ -169,6 +169,12 @@ export default function CalendarTab() {
     onOpen()
   }
 
+  function openAllDay(day: Date) {
+    const dateStr = toDateInput(day)
+    setForm({ ...EMPTY_FORM, isAllDay: true, startDate: dateStr, endDate: dateStr })
+    onOpen()
+  }
+
   function openDayView(day: Date) {
     setAnchor(startOfDay(day))
     setView('day')
@@ -322,6 +328,7 @@ export default function CalendarTab() {
             now={now}
             currentUserId={user?.id}
             onSlotClick={openSlot}
+            onAllDayClick={openAllDay}
             onDelete={handleDelete}
           />
         )}

--- a/src/components/Calendar/CalendarTab.tsx
+++ b/src/components/Calendar/CalendarTab.tsx
@@ -14,7 +14,7 @@ import {
   Spinner,
   Center,
 } from '@chakra-ui/react'
-import { ChevronLeftIcon, ChevronRightIcon, ChevronDownIcon, AddIcon } from '@chakra-ui/icons'
+import { ChevronLeftIcon, ChevronRightIcon, ChevronDownIcon } from '@chakra-ui/icons'
 import { supabase } from '../../lib/supabase'
 import { useAuth } from '../../hooks/useAuth'
 import { Button } from '../ui/Button'
@@ -301,9 +301,6 @@ export default function CalendarTab() {
                 ))}
               </MenuList>
             </Menu>
-            <Button variant="signal" leftIcon={<AddIcon boxSize={3} />} onClick={openBlank}>
-              予定を追加
-            </Button>
           </HStack>
         </Flex>
 

--- a/src/components/Calendar/TimeGridView.tsx
+++ b/src/components/Calendar/TimeGridView.tsx
@@ -23,6 +23,7 @@ interface TimeGridViewProps {
   now: Date
   currentUserId: string | undefined
   onSlotClick: (day: Date, minute: number) => void
+  onAllDayClick: (day: Date) => void
   onDelete: (id: string) => void
 }
 
@@ -32,6 +33,7 @@ export function TimeGridView({
   now,
   currentUserId,
   onSlotClick,
+  onAllDayClick,
   onDelete,
 }: TimeGridViewProps) {
   const scrollRef = useRef<HTMLDivElement>(null)
@@ -49,7 +51,6 @@ export function TimeGridView({
     return Math.max(0, Math.min(23 * 60 + 45, snapped))
   }
 
-  const hasAllDay = events.some((e) => e.isAllDay)
   const minColWidth = days.length === 1 ? 'auto' : '100px'
 
   return (
@@ -105,8 +106,7 @@ export function TimeGridView({
             })}
           </Flex>
 
-          {/* All-day row */}
-          {hasAllDay && (
+          {/* All-day row — always visible so empty days can be clicked to add */}
             <Flex borderBottom="1px solid" borderColor="gray.200" bg="gray.50">
               <Center w={`${GUTTER}px`} flexShrink={0} px={1}>
                 <Text fontSize="10px" fontWeight="bold" color="gray.400">
@@ -126,6 +126,10 @@ export function TimeGridView({
                     minH="32px"
                     borderLeft="1px solid"
                     borderColor="gray.100"
+                    cursor="pointer"
+                    transition="background 0.1s"
+                    _hover={{ bg: 'primary.50' }}
+                    onClick={() => onAllDayClick(d)}
                   >
                     {allDay.map((ev) => {
                       const style = EVENT_STYLE[ev.sharingState as SharingState] ?? EVENT_STYLE.private
@@ -143,6 +147,7 @@ export function TimeGridView({
                           borderRadius="sm"
                           px={1.5}
                           py={0.5}
+                          onClick={(e) => e.stopPropagation()}
                         >
                           <Text fontSize="xs" fontWeight="600" color={style.text} noOfLines={1}>
                             {ev.name}
@@ -170,7 +175,6 @@ export function TimeGridView({
                 )
               })}
             </Flex>
-          )}
             </Box>
 
             {/* Time grid — scrolls under the sticky header above */}

--- a/src/components/Calendar/TimeGridView.tsx
+++ b/src/components/Calendar/TimeGridView.tsx
@@ -56,8 +56,18 @@ export function TimeGridView({
     <Box bg="paper-2" border="1px solid" borderColor="gray.200" borderRadius="xl" overflow="hidden">
       <Box overflowX="auto">
         <Box minW={days.length === 1 ? 'auto' : '760px'}>
-          {/* Day headers */}
-          <Flex borderBottom="1px solid" borderColor="gray.200">
+          {/* Single scroll container so the header and the time grid share the
+              same width and the same scrollbar — keeps columns aligned. */}
+          <Flex
+            ref={scrollRef}
+            direction="column"
+            overflowY="auto"
+            maxH={{ base: '60vh', md: 'calc(100vh - 320px)' }}
+          >
+            {/* Sticky header: day labels + all-day row stay visible while scrolling */}
+            <Box position="sticky" top={0} zIndex={4} bg="paper-2">
+              {/* Day headers */}
+              <Flex borderBottom="1px solid" borderColor="gray.200">
             <Box w={`${GUTTER}px`} flexShrink={0} />
             {days.map((d) => {
               const today = isSameDay(d, now)
@@ -161,14 +171,10 @@ export function TimeGridView({
               })}
             </Flex>
           )}
+            </Box>
 
-          {/* Scrollable time grid */}
-          <Flex
-            ref={scrollRef}
-            overflowY="auto"
-            maxH={{ base: '60vh', md: 'calc(100vh - 320px)' }}
-            position="relative"
-          >
+            {/* Time grid — scrolls under the sticky header above */}
+            <Flex position="relative">
             <Box w={`${GUTTER}px`} flexShrink={0} position="relative" h={`${TOTAL_HEIGHT}px`}>
               {Array.from({ length: 23 }).map((_, i) => {
                 const hour = i + 1
@@ -331,6 +337,7 @@ export function TimeGridView({
                   </Box>
                 )
               })}
+            </Flex>
             </Flex>
           </Flex>
         </Box>


### PR DESCRIPTION
## 概要
PR #29 マージ後に積んだカレンダー改善をまとめた PR です（#30 の年月ジャンプも取り込み済み）。

## 変更点
1. **終日行クリックで終日予定を追加**: 日付ヘッダー直下の「終日」セルをクリックすると、その日付で終日プリフィルした追加モーダルが開く。空の日でも追加できるよう終日行を常時表示に。
2. **サイドバーに常時表示の「今日」カード**: 日付バッジ＋曜日付き日付を常時表示。クリックで今日へジャンプ＆ミニカレンダーを今月へ。ミニカレンダーの today にも枠線。
3. **スクロールバーによる列ズレを修正**: 日付ヘッダーとタイムグリッドを1つのスクロール領域にまとめ、ヘッダー(＋終日行)を sticky 化。同一幅・同一スクロールバーで列が揃い、スクロール中もヘッダー固定。
4. **ツールバーの「予定を追加」ボタンを削除**: サイドバーの「作成」とスロットクリックで追加できるため不要。

## 補足
- main(#30) の「ミニカレンダー年月ジャンプ」と競合した CalendarSidebar はマージ解消済み（今日カードと年月ジャンプを両立）。
- ビルド・Lint クリーン。

🤖 Generated with [Claude Code](https://claude.com/claude-code)