### PR TITLE
feat: マップにチームメンバーの位置を表示

### DIFF
--- a/src/components/Map/MapTab.tsx
+++ b/src/components/Map/MapTab.tsx
@@ -75,7 +75,7 @@ function TripleClickRecenter({ position }: { position: LatLng | null }) {
 }
 
 export default function MapTab() {
-  const { user } = useAuth()
+  const { user, teams } = useAuth()
   const { locations, fetchLocations } = useRealtimeLocations()
   const [sharingState, setSharingState] = useState<LocationRow['sharingState']>('private')
   const [currentPosition, setCurrentPosition] = useState<LatLng | null>(null)
@@ -83,15 +83,51 @@ export default function MapTab() {
   const [saving, setSaving] = useState(false)
   const [lastSavedAt, setLastSavedAt] = useState<string | null>(null)
   const [tileLayer, setTileLayer] = useState<TileLayerKey>('map')
+  // displayName for every teammate (across all of the user's teams)
+  const [memberNames, setMemberNames] = useState<Map<string, string>>(new Map())
 
+  const teamIds = useMemo(() => teams.map((t) => t.id), [teams])
+
+  const fetchTeamMembers = useCallback(async () => {
+    if (teamIds.length === 0) {
+      setMemberNames(new Map())
+      return
+    }
+    const { data: rows } = await supabase
+      .from('user_teams')
+      .select('userId')
+      .in('teamId', teamIds)
+    const ids = Array.from(new Set((rows ?? []).map((r) => r.userId)))
+    if (ids.length === 0) {
+      setMemberNames(new Map())
+      return
+    }
+    const { data: users } = await supabase
+      .from('users')
+      .select('id, displayName')
+      .in('id', ids)
+    setMemberNames(new Map((users ?? []).map((u) => [u.id, u.displayName])))
+  }, [teamIds])
+
+  // Only show teammates' pins (and always your own).
   const markers = useMemo(
-    () => locations.filter((loc) => loc.lat !== null && loc.lng !== null),
-    [locations],
+    () =>
+      locations.filter(
+        (loc) =>
+          loc.lat !== null &&
+          loc.lng !== null &&
+          (loc.userId === user?.id || memberNames.has(loc.userId)),
+      ),
+    [locations, memberNames, user?.id],
   )
 
   useEffect(() => {
     void fetchLocations()
   }, [fetchLocations])
+
+  useEffect(() => {
+    void fetchTeamMembers()
+  }, [fetchTeamMembers])
 
   useEffect(() => {
     if (!user) return
@@ -156,8 +192,8 @@ export default function MapTab() {
   const handleRefresh = useCallback(async () => {
     if (!user || !currentPosition) return
     await upsertLocation(currentPosition, sharingState)
-    await fetchLocations()
-  }, [user, currentPosition, sharingState, upsertLocation, fetchLocations])
+    await Promise.all([fetchLocations(), fetchTeamMembers()])
+  }, [user, currentPosition, sharingState, upsertLocation, fetchLocations, fetchTeamMembers])
 
   const currentPositionLabel = currentPosition
     ? `${currentPosition.lat.toFixed(5)}, ${currentPosition.lng.toFixed(5)}`
@@ -170,7 +206,7 @@ export default function MapTab() {
           <Text fontSize="2xl" fontWeight="semibold">
             マップ
           </Text>
-          <Text color="gray.600">位置共有ステータスを選択すると、現在地が Supabase の locations テーブルへ送信されます。</Text>
+          <Text color="gray.600">共有範囲を選んで「マップを更新」すると、現在地が送信され、チームメンバーの位置が表示されます。</Text>
           <HStack spacing={3} flexWrap="wrap">
             <Badge colorScheme={sharingState === 'private' ? 'gray' : sharingState === 'friends' ? 'blue' : 'purple'}>
               {sharingState}
@@ -249,7 +285,11 @@ export default function MapTab() {
               position={[loc.lat ?? 0, loc.lng ?? 0]}
               icon={MapPin(loc.userId === user?.id ? '#2B6CB0' : undefined)}
             >
-              <Popup>{loc.userId === user?.id ? 'あなた' : loc.userId}</Popup>
+              <Popup>
+                {loc.userId === user?.id
+                  ? 'あなた'
+                  : memberNames.get(loc.userId) ?? 'チームメンバー'}
+              </Popup>
             </Marker>
           ))}
         </MapContainer>


### PR DESCRIPTION
## 概要
マップを「全ユーザーの生 userId 表示」から「チームメンバー中心・表示名表示」に改善しました。

## 変更内容
- **チームメンバー取得** — 所属チームから `user_teams` → `users` を辿り、メンバーの `displayName` をまとめて取得
- **ピンの絞り込み** — 自分＋チームメンバーの位置だけを表示（無関係なユーザーは出さない）
- **表示名表示** — Popup を生の `userId` から表示名へ（自分は「あなた」、未取得時は「チームメンバー」）
- **更新ボタン** — 位置一覧とメンバー一覧を同時に再取得
- 説明文を新しい挙動に合わせて更新

## レビュアーへの補足
- 他メンバーの位置が実際に取得できるかは Supabase の `locations` テーブルの **RLS ポリシー**に依存します。`sharing_state`（private/friends/team）に応じて他ユーザー行が SELECT 可能になっている必要があります。未設定だと team 共有でもクエリに返らない可能性があります（本 PR はフロント側の対応）。

## 確認
- [x] `npm run build` が通る
- [ ] 動作確認（RLS 含む）

🤖 Generated with [Claude Code](https://claude.com/claude-code)