### PR TITLE
feat: ユーザーメニュー（プロフィール/設定）を追加

### DIFF
--- a/src/components/Account/AccountModal.tsx
+++ b/src/components/Account/AccountModal.tsx
@@ -1,0 +1,204 @@
+import { useState } from 'react'
+import {
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  ModalCloseButton,
+  Tabs,
+  TabList,
+  Tab,
+  TabPanels,
+  TabPanel,
+  FormControl,
+  FormLabel,
+  HStack,
+  VStack,
+  Avatar,
+  Box,
+  Text,
+  Divider,
+  useToast,
+} from '@chakra-ui/react'
+import { useAuth } from '../../hooks/useAuth'
+import { Button } from '../ui/Button'
+import { Input } from '../ui/Input'
+
+interface AccountModalProps {
+  isOpen: boolean
+  onClose: () => void
+  initialTab?: number
+}
+
+export function AccountModal({ isOpen, onClose, initialTab = 0 }: AccountModalProps) {
+  const { user, profile, updateProfile, refreshProfile, signOut } = useAuth()
+  const toast = useToast()
+  // Initialized from the current profile on mount. The parent mounts this only
+  // while open, so each open starts fresh from the latest profile.
+  const [tabIndex, setTabIndex] = useState(initialTab)
+  const [saving, setSaving] = useState(false)
+  const [form, setForm] = useState(() => ({
+    displayName: profile?.displayName ?? '',
+    familyName: profile?.familyName ?? '',
+    firstName: profile?.firstName ?? '',
+    phoneNumber: profile?.phoneNumber ?? '',
+  }))
+
+  const email = profile?.email ?? user?.email ?? ''
+  const joinedAt = profile?.createdAt
+    ? new Date(profile.createdAt).toLocaleDateString('ja-JP', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+      })
+    : '—'
+
+  async function handleSave() {
+    if (!user) return
+    if (!form.displayName.trim()) {
+      toast({ status: 'warning', title: '表示名を入力してください' })
+      return
+    }
+    setSaving(true)
+    const { error } = await updateProfile(user.id, {
+      displayName: form.displayName.trim(),
+      familyName: form.familyName.trim() || null,
+      firstName: form.firstName.trim() || null,
+      phoneNumber: form.phoneNumber.trim() || null,
+    })
+    setSaving(false)
+    if (error) {
+      toast({ status: 'error', title: '保存できませんでした', description: error.message })
+      return
+    }
+    await refreshProfile()
+    toast({ status: 'success', title: 'プロフィールを更新しました' })
+    onClose()
+  }
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} isCentered size="md">
+      <ModalOverlay bg="blackAlpha.500" backdropFilter="blur(2px)" />
+      <ModalContent mx={4}>
+        <ModalHeader fontFamily="heading">アカウント</ModalHeader>
+        <ModalCloseButton borderRadius="full" />
+        <ModalBody>
+          {/* Account summary */}
+          <HStack spacing={3} mb={4}>
+            <Avatar size="md" name={form.displayName || email} bg="primary.500" color="white" />
+            <Box minW={0}>
+              <Text fontWeight="700" color="gray.900" noOfLines={1}>
+                {form.displayName || '名称未設定'}
+              </Text>
+              <Text fontSize="sm" color="gray.500" noOfLines={1}>
+                {email}
+              </Text>
+            </Box>
+          </HStack>
+
+          <Tabs index={tabIndex} onChange={setTabIndex} variant="unstyled">
+            <TabList gap={1} bg="gray.100" p={1} borderRadius="lg" mb={4}>
+              {['プロフィール', '設定'].map((label) => (
+                <Tab
+                  key={label}
+                  flex={1}
+                  borderRadius="md"
+                  fontSize="sm"
+                  fontWeight="semibold"
+                  color="gray.500"
+                  _selected={{ bg: 'paper-2', color: 'primary.700', boxShadow: 'sm' }}
+                >
+                  {label}
+                </Tab>
+              ))}
+            </TabList>
+
+            <TabPanels>
+              {/* Profile editing */}
+              <TabPanel p={0}>
+                <VStack spacing={4} align="stretch">
+                  <FormControl isRequired>
+                    <FormLabel>表示名</FormLabel>
+                    <Input
+                      value={form.displayName}
+                      placeholder="例: 山田 太郎"
+                      onChange={(e) => setForm({ ...form, displayName: e.target.value })}
+                    />
+                  </FormControl>
+                  <HStack spacing={3} align="start">
+                    <FormControl>
+                      <FormLabel>姓</FormLabel>
+                      <Input
+                        value={form.familyName}
+                        onChange={(e) => setForm({ ...form, familyName: e.target.value })}
+                      />
+                    </FormControl>
+                    <FormControl>
+                      <FormLabel>名</FormLabel>
+                      <Input
+                        value={form.firstName}
+                        onChange={(e) => setForm({ ...form, firstName: e.target.value })}
+                      />
+                    </FormControl>
+                  </HStack>
+                  <FormControl>
+                    <FormLabel>電話番号</FormLabel>
+                    <Input
+                      type="tel"
+                      value={form.phoneNumber}
+                      placeholder="任意"
+                      onChange={(e) => setForm({ ...form, phoneNumber: e.target.value })}
+                    />
+                  </FormControl>
+                </VStack>
+              </TabPanel>
+
+              {/* Account info + sign out */}
+              <TabPanel p={0}>
+                <VStack spacing={3} align="stretch">
+                  <Box>
+                    <Text fontSize="xs" fontWeight="semibold" color="gray.500">
+                      メールアドレス
+                    </Text>
+                    <Text color="gray.800">{email}</Text>
+                  </Box>
+                  <Divider borderColor="gray.200" />
+                  <Box>
+                    <Text fontSize="xs" fontWeight="semibold" color="gray.500">
+                      登録日
+                    </Text>
+                    <Text color="gray.800">{joinedAt}</Text>
+                  </Box>
+                  <Divider borderColor="gray.200" />
+                  <Button
+                    variant="secondary"
+                    color="danger.600"
+                    onClick={() => {
+                      onClose()
+                      void signOut()
+                    }}
+                  >
+                    ログアウト
+                  </Button>
+                </VStack>
+              </TabPanel>
+            </TabPanels>
+          </Tabs>
+        </ModalBody>
+
+        <ModalFooter gap={2}>
+          <Button variant="ghost" onClick={onClose}>
+            閉じる
+          </Button>
+          {tabIndex === 0 && (
+            <Button variant="primary" onClick={handleSave} isLoading={saving} loadingText="保存中">
+              保存する
+            </Button>
+          )}
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  )
+}

--- a/src/components/Layout/MainLayout.tsx
+++ b/src/components/Layout/MainLayout.tsx
@@ -20,17 +20,27 @@ import {
   Avatar,
   HStack,
   Container,
+  useDisclosure,
 } from '@chakra-ui/react'
 import { useAuth } from '../../hooks/useAuth'
 import { Wordmark } from '../ui/Wordmark'
+import { AccountModal } from '../Account/AccountModal'
 
 // CalendarTab is implemented in src/components/Calendar/CalendarTab.tsx
 // MapTab (live Leaflet map) is implemented in src/components/Map/MapTab.tsx
 
 export function MainLayout() {
-  const { profile, signOut } = useAuth()
+  const { user, profile, signOut } = useAuth()
   const [tabIndex, setTabIndex] = useState(0)
   const name = profile?.displayName ?? 'ゲスト'
+  const email = profile?.email ?? user?.email ?? ''
+
+  const account = useDisclosure()
+  const [accountTab, setAccountTab] = useState(0)
+  const openAccount = (tab: number) => {
+    setAccountTab(tab)
+    account.onOpen()
+  }
 
   return (
     <Box minH="100vh" bg="paper">
@@ -90,17 +100,33 @@ export function MainLayout() {
                 >
                   <Avatar size="sm" name={name} bg="primary.500" color="white" />
                 </MenuButton>
-                <MenuList borderRadius="xl" borderColor="gray.200" boxShadow="lg">
-                  <Box px={3} py={2}>
-                    <Text fontSize="xs" color="gray.500">
-                      ログイン中
-                    </Text>
-                    <Text fontWeight="semibold" color="gray.900">
-                      {name}
-                    </Text>
-                  </Box>
+                <MenuList borderRadius="xl" borderColor="gray.200" boxShadow="lg" minW="240px">
+                  <HStack px={3} py={2} spacing={3}>
+                    <Avatar size="sm" name={name} bg="primary.500" color="white" />
+                    <Box minW={0}>
+                      <Text fontWeight="semibold" color="gray.900" noOfLines={1}>
+                        {name}
+                      </Text>
+                      {email && (
+                        <Text fontSize="xs" color="gray.500" noOfLines={1}>
+                          {email}
+                        </Text>
+                      )}
+                    </Box>
+                  </HStack>
                   <MenuDivider borderColor="gray.200" />
-                  <MenuItem onClick={() => signOut()} color="danger.600">
+                  <MenuItem icon={<Box as="span">👤</Box>} onClick={() => openAccount(0)}>
+                    プロフィール
+                  </MenuItem>
+                  <MenuItem icon={<Box as="span">⚙️</Box>} onClick={() => openAccount(1)}>
+                    設定
+                  </MenuItem>
+                  <MenuDivider borderColor="gray.200" />
+                  <MenuItem
+                    icon={<Box as="span">🚪</Box>}
+                    onClick={() => signOut()}
+                    color="danger.600"
+                  >
                     ログアウト
                   </MenuItem>
                 </MenuList>
@@ -123,6 +149,10 @@ export function MainLayout() {
           </TabPanels>
         </Container>
       </Tabs>
+
+      {account.isOpen && (
+        <AccountModal isOpen onClose={account.onClose} initialTab={accountTab} />
+      )}
     </Box>
   )
 }


### PR DESCRIPTION
## 概要
画像（GitHub のアバターメニュー）を参考に、ヘッダーのアバターを押すと**ユーザー管理メニュー**が開くようにしました。

## 変更点
- **アバターメニューを拡張**: 先頭にユーザー情報（名前＋メール）、項目に **プロフィール / 設定 / ログアウト** を追加（アイコン付き）。
- **AccountModal を新規追加**（`src/components/Account/AccountModal.tsx`）:
  - **プロフィールタブ**: 表示名・姓・名・電話番号を編集し `updateProfile` で保存（保存後に `refreshProfile`／トースト通知）
  - **設定タブ**: メールアドレス・登録日の表示＋ログアウト
  - 「プロフィール」「設定」からそれぞれ該当タブで開く
- モーダルは開いている間だけマウントし、毎回最新のプロフィールで初期化（synchronous setState in effect を避けるための実装）

## 備考
- 既存の `useAuth`（`updateProfile`/`refreshProfile`/`signOut`）をそのまま利用。DB スキーマ変更なし。
- ビルド・Lint クリーン。

🤖 Generated with [Claude Code](https://claude.com/claude-code)