### PR TITLE
feat(calendar): 既存予定をクリックして編集

### DIFF
--- a/src/components/Calendar/CalendarTab.tsx
+++ b/src/components/Calendar/CalendarTab.tsx
@@ -24,6 +24,7 @@ import { MonthView } from './MonthView'
 import { CalendarSidebar } from './CalendarSidebar'
 import {
   EMPTY_FORM,
+  eventToForm,
   startOfWeek,
   startOfDay,
   addDays,
@@ -53,6 +54,8 @@ export default function CalendarTab() {
   const { isOpen, onOpen, onClose } = useDisclosure()
   const toast = useToast()
   const [form, setForm] = useState<EventForm>(EMPTY_FORM)
+  // id of the event being edited, or null when creating a new one.
+  const [editingId, setEditingId] = useState<string | null>(null)
 
   const teamIds = useMemo(() => teams.map((t) => t.id), [teams])
 
@@ -152,6 +155,7 @@ export default function CalendarTab() {
   }, [view, anchor])
 
   function openBlank() {
+    setEditingId(null)
     setForm(EMPTY_FORM)
     onOpen()
   }
@@ -159,6 +163,7 @@ export default function CalendarTab() {
   function openSlot(day: Date, minute: number) {
     const dateStr = toDateInput(day)
     const endMinute = minute + 60
+    setEditingId(null)
     setForm({
       ...EMPTY_FORM,
       startDate: dateStr,
@@ -171,7 +176,15 @@ export default function CalendarTab() {
 
   function openAllDay(day: Date) {
     const dateStr = toDateInput(day)
+    setEditingId(null)
     setForm({ ...EMPTY_FORM, isAllDay: true, startDate: dateStr, endDate: dateStr })
+    onOpen()
+  }
+
+  // Open the modal in edit mode for an existing event.
+  function openEdit(ev: EventRow) {
+    setEditingId(ev.id)
+    setForm(eventToForm(ev))
     onOpen()
   }
 
@@ -211,22 +224,24 @@ export default function CalendarTab() {
       return
     }
 
-    const { error } = await supabase.from('events').insert({
-      createdBy: user.id,
-      teamId,
+    const payload = {
       name: form.name,
       startAt: start.toISOString(),
       endAt: end.toISOString(),
       isAllDay: form.isAllDay,
       eventLocation: form.eventLocation || null,
       sharingState: form.sharingState as SharingState,
-    })
+    }
+
+    const { error } = editingId
+      ? await supabase.from('events').update(payload).eq('id', editingId)
+      : await supabase.from('events').insert({ createdBy: user.id, teamId, ...payload })
 
     if (error) {
-      console.error('create event error', error)
+      console.error('save event error', error)
       toast({
         status: 'error',
-        title: '予定を追加できませんでした',
+        title: editingId ? '予定を保存できませんでした' : '予定を追加できませんでした',
         description: error.message,
         duration: 8000,
         isClosable: true,
@@ -235,8 +250,17 @@ export default function CalendarTab() {
     }
 
     setForm(EMPTY_FORM)
+    setEditingId(null)
     onClose()
     fetchEvents()
+  }
+
+  // Delete the event currently open in the edit modal.
+  async function handleDeleteCurrent() {
+    if (!editingId) return
+    await handleDelete(editingId)
+    setEditingId(null)
+    onClose()
   }
 
   async function handleDelete(id: string) {
@@ -320,6 +344,7 @@ export default function CalendarTab() {
             events={visibleEvents}
             now={now}
             onDayClick={openDayView}
+            onEventClick={openEdit}
           />
         ) : (
           <TimeGridView
@@ -329,12 +354,21 @@ export default function CalendarTab() {
             currentUserId={user?.id}
             onSlotClick={openSlot}
             onAllDayClick={openAllDay}
+            onEventClick={openEdit}
             onDelete={handleDelete}
           />
         )}
       </Box>
 
-      <EventModal isOpen={isOpen} onClose={onClose} form={form} setForm={setForm} onSubmit={handleCreate} />
+      <EventModal
+        isOpen={isOpen}
+        onClose={onClose}
+        form={form}
+        setForm={setForm}
+        onSubmit={handleCreate}
+        mode={editingId ? 'edit' : 'create'}
+        onDelete={handleDeleteCurrent}
+      />
     </Flex>
   )
 }

--- a/src/components/Calendar/EventModal.tsx
+++ b/src/components/Calendar/EventModal.tsx
@@ -26,15 +26,26 @@ interface EventModalProps {
   form: EventForm
   setForm: (f: EventForm) => void
   onSubmit: () => void
+  mode?: 'create' | 'edit'
+  onDelete?: () => void
 }
 
-export function EventModal({ isOpen, onClose, form, setForm, onSubmit }: EventModalProps) {
+export function EventModal({
+  isOpen,
+  onClose,
+  form,
+  setForm,
+  onSubmit,
+  mode = 'create',
+  onDelete,
+}: EventModalProps) {
   const sharing = SHARING[form.sharingState as SharingState] ?? SHARING.private
+  const isEdit = mode === 'edit'
   return (
     <Modal isOpen={isOpen} onClose={onClose} isCentered>
       <ModalOverlay bg="blackAlpha.500" backdropFilter="blur(2px)" />
       <ModalContent mx={4}>
-        <ModalHeader fontFamily="heading">予定を追加</ModalHeader>
+        <ModalHeader fontFamily="heading">{isEdit ? '予定を編集' : '予定を追加'}</ModalHeader>
         <ModalCloseButton borderRadius="full" />
         <ModalBody>
           <VStack spacing={4} align="stretch">
@@ -142,6 +153,11 @@ export function EventModal({ isOpen, onClose, form, setForm, onSubmit }: EventMo
         </ModalBody>
 
         <ModalFooter gap={2}>
+          {isEdit && onDelete && (
+            <Button variant="ghost" color="danger.600" mr="auto" onClick={onDelete}>
+              削除
+            </Button>
+          )}
           <Button variant="ghost" onClick={onClose}>
             キャンセル
           </Button>
@@ -150,7 +166,7 @@ export function EventModal({ isOpen, onClose, form, setForm, onSubmit }: EventMo
             onClick={onSubmit}
             isDisabled={!form.name || !form.startDate || (!form.isAllDay && !form.startTime)}
           >
-            作成する
+            {isEdit ? '保存する' : '作成する'}
           </Button>
         </ModalFooter>
       </ModalContent>

--- a/src/components/Calendar/MonthView.tsx
+++ b/src/components/Calendar/MonthView.tsx
@@ -16,11 +16,12 @@ interface MonthViewProps {
   events: EventRow[]
   now: Date
   onDayClick: (day: Date) => void
+  onEventClick: (ev: EventRow) => void
 }
 
 const MAX_CHIPS = 3
 
-export function MonthView({ anchor, events, now, onDayClick }: MonthViewProps) {
+export function MonthView({ anchor, events, now, onDayClick, onEventClick }: MonthViewProps) {
   const days = monthGridDays(anchor)
 
   return (
@@ -110,6 +111,12 @@ export function MonthView({ anchor, events, now, onDayClick }: MonthViewProps) {
                       px={1}
                       h="18px"
                       overflow="hidden"
+                      cursor="pointer"
+                      _hover={{ bg: ev.isAllDay ? style.bg : 'gray.100' }}
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        onEventClick(ev)
+                      }}
                     >
                       {!ev.isAllDay && (
                         <Box boxSize="6px" borderRadius="full" bg={style.dot} flexShrink={0} />

--- a/src/components/Calendar/TimeGridView.tsx
+++ b/src/components/Calendar/TimeGridView.tsx
@@ -24,6 +24,7 @@ interface TimeGridViewProps {
   currentUserId: string | undefined
   onSlotClick: (day: Date, minute: number) => void
   onAllDayClick: (day: Date) => void
+  onEventClick: (ev: EventRow) => void
   onDelete: (id: string) => void
 }
 
@@ -34,6 +35,7 @@ export function TimeGridView({
   currentUserId,
   onSlotClick,
   onAllDayClick,
+  onEventClick,
   onDelete,
 }: TimeGridViewProps) {
   const scrollRef = useRef<HTMLDivElement>(null)
@@ -147,7 +149,11 @@ export function TimeGridView({
                           borderRadius="sm"
                           px={1.5}
                           py={0.5}
-                          onClick={(e) => e.stopPropagation()}
+                          cursor="pointer"
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            onEventClick(ev)
+                          }}
                         >
                           <Text fontSize="xs" fontWeight="600" color={style.text} noOfLines={1}>
                             {ev.name}
@@ -165,7 +171,10 @@ export function TimeGridView({
                               opacity={0}
                               _groupHover={{ opacity: 1 }}
                               _hover={{ color: 'danger.500', bg: 'transparent' }}
-                              onClick={() => onDelete(ev.id)}
+                              onClick={(e) => {
+                                e.stopPropagation()
+                                onDelete(ev.id)
+                              }}
                             />
                           )}
                         </Flex>
@@ -271,10 +280,13 @@ export function TimeGridView({
                           px={1.5}
                           py={1}
                           overflow="hidden"
-                          cursor="default"
+                          cursor="pointer"
                           transition="filter 0.1s"
                           _hover={{ filter: 'brightness(0.97)', zIndex: 2 }}
-                          onClick={(e) => e.stopPropagation()}
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            onEventClick(ev)
+                          }}
                         >
                           <Flex justify="space-between" align="start" gap={1}>
                             <Text

--- a/src/components/Calendar/calendarUtils.ts
+++ b/src/components/Calendar/calendarUtils.ts
@@ -130,6 +130,36 @@ export const EMPTY_FORM: EventForm = {
   sharingState: 'private',
 }
 
+// Convert a stored event into the editable form shape.
+export function eventToForm(ev: EventRow): EventForm {
+  const start = new Date(ev.startAt)
+  const end = new Date(ev.endAt)
+  if (ev.isAllDay) {
+    // Stored end is the midnight after the last day → step back one day to show
+    // the inclusive end date the user originally picked.
+    return {
+      name: ev.name,
+      isAllDay: true,
+      startDate: toDateInput(start),
+      startTime: '',
+      endDate: toDateInput(addDays(end, -1)),
+      endTime: '',
+      eventLocation: ev.eventLocation ?? '',
+      sharingState: ev.sharingState,
+    }
+  }
+  return {
+    name: ev.name,
+    isAllDay: false,
+    startDate: toDateInput(start),
+    startTime: minuteToTime(minutesOfDay(start)),
+    endDate: toDateInput(end),
+    endTime: minuteToTime(minutesOfDay(end)),
+    eventLocation: ev.eventLocation ?? '',
+    sharingState: ev.sharingState,
+  }
+}
+
 export type Positioned = {
   ev: EventRow
   start: number // minutes from midnight (clamped to this day)


### PR DESCRIPTION
## 概要
すでにある予定をクリックすると編集モーダルが開くようにしました。

## 「編集モーダルは追加と別物にすべき？」への回答
**いいえ、同じモーダルを使い回します**（Google カレンダーも同一ダイアログ）。`mode`（create/edit）で切り替え、重複を避けています。

## 変更点
- **予定クリックで編集**: 週/日のタイムグリッド・終日行・月表示のチップ、いずれもクリックで編集モーダルを開く
- **EventModal に編集モード**: タイトル「予定を編集」、ボタン「保存する」、編集時のみ**削除ボタン**を表示
- **保存は insert/update を出し分け**（`editingId` で判定）。編集モーダルからの削除にも対応
- `calendarUtils.eventToForm`: 保存済みイベント→フォーム変換（終日は終了日を1日戻して復元）
- 削除ボタンのクリックは `stopPropagation` で編集モーダルが開かないように

## 備考
- 更新/削除は RLS（`createdBy = auth.uid()`）で本人のみ許可。他人の予定を保存しようとした場合はエラーをトースト表示します。本人限定に制限したい場合は調整可能です。
- ビルド・Lint クリーン。

🤖 Generated with [Claude Code](https://claude.com/claude-code)