### PR TITLE
feat: チーム内チャット + 予定の編集

### DIFF
--- a/src/components/Calendar/CalendarTab.tsx
+++ b/src/components/Calendar/CalendarTab.tsx
@@ -24,6 +24,7 @@ import { MonthView } from './MonthView'
 import { CalendarSidebar } from './CalendarSidebar'
 import {
   EMPTY_FORM,
+  eventToForm,
   startOfWeek,
   startOfDay,
   addDays,
@@ -54,6 +55,13 @@ export default function CalendarTab() {
   const { isOpen, onOpen, onClose } = useDisclosure()
   const toast = useToast()
   const [form, setForm] = useState<EventForm>(EMPTY_FORM)
+  // id of the event being edited; null when creating a new one
+  const [editingId, setEditingId] = useState<string | null>(null)
+
+  function closeModal() {
+    setEditingId(null)
+    onClose()
+  }
 
   const teamIds = useMemo(() => teams.map((t) => t.id), [teams])
 
@@ -161,6 +169,7 @@ export default function CalendarTab() {
   }, [view, anchor])
 
   function openBlank() {
+    setEditingId(null)
     setForm(EMPTY_FORM)
     onOpen()
   }
@@ -168,6 +177,7 @@ export default function CalendarTab() {
   function openSlot(day: Date, minute: number) {
     const dateStr = toDateInput(day)
     const endMinute = minute + 60
+    setEditingId(null)
     setForm({
       ...EMPTY_FORM,
       startDate: dateStr,
@@ -180,7 +190,14 @@ export default function CalendarTab() {
 
   function openAllDay(day: Date) {
     const dateStr = toDateInput(day)
+    setEditingId(null)
     setForm({ ...EMPTY_FORM, isAllDay: true, startDate: dateStr, endDate: dateStr })
+    onOpen()
+  }
+
+  function openEdit(ev: EventRow) {
+    setEditingId(ev.id)
+    setForm(eventToForm(ev))
     onOpen()
   }
 
@@ -189,7 +206,7 @@ export default function CalendarTab() {
     setView('day')
   }
 
-  async function handleCreate() {
+  async function handleSubmit() {
     if (!user) {
       toast({ status: 'error', title: 'ログインが必要です' })
       return
@@ -202,7 +219,6 @@ export default function CalendarTab() {
       })
       return
     }
-    const teamId = teams[0].id
 
     let start: Date
     let end: Date
@@ -220,22 +236,24 @@ export default function CalendarTab() {
       return
     }
 
-    const { error } = await supabase.from('events').insert({
-      createdBy: user.id,
-      teamId,
+    const values = {
       name: form.name,
       startAt: start.toISOString(),
       endAt: end.toISOString(),
       isAllDay: form.isAllDay,
       eventLocation: form.eventLocation || null,
       sharingState: form.sharingState as SharingState,
-    })
+    }
+
+    const { error } = editingId
+      ? await supabase.from('events').update(values).eq('id', editingId)
+      : await supabase.from('events').insert({ ...values, createdBy: user.id, teamId: teams[0].id })
 
     if (error) {
-      console.error('create event error', error)
+      console.error('save event error', error)
       toast({
         status: 'error',
-        title: '予定を追加できませんでした',
+        title: editingId ? '予定を更新できませんでした' : '予定を追加できませんでした',
         description: error.message,
         duration: 8000,
         isClosable: true,
@@ -244,7 +262,7 @@ export default function CalendarTab() {
     }
 
     setForm(EMPTY_FORM)
-    onClose()
+    closeModal()
     fetchEvents()
   }
 
@@ -338,6 +356,7 @@ export default function CalendarTab() {
             events={visibleEvents}
             now={now}
             onDayClick={openDayView}
+            onEventClick={openEdit}
           />
         ) : (
           <TimeGridView
@@ -347,12 +366,20 @@ export default function CalendarTab() {
             currentUserId={user?.id}
             onSlotClick={openSlot}
             onAllDayClick={openAllDay}
+            onEventClick={openEdit}
             onDelete={handleDelete}
           />
         )}
       </Box>
 
-      <EventModal isOpen={isOpen} onClose={onClose} form={form} setForm={setForm} onSubmit={handleCreate} />
+      <EventModal
+        isOpen={isOpen}
+        onClose={closeModal}
+        form={form}
+        setForm={setForm}
+        onSubmit={handleSubmit}
+        isEditing={!!editingId}
+      />
     </Flex>
   )
 }

--- a/src/components/Calendar/EventModal.tsx
+++ b/src/components/Calendar/EventModal.tsx
@@ -26,15 +26,16 @@ interface EventModalProps {
   form: EventForm
   setForm: (f: EventForm) => void
   onSubmit: () => void
+  isEditing?: boolean
 }
 
-export function EventModal({ isOpen, onClose, form, setForm, onSubmit }: EventModalProps) {
+export function EventModal({ isOpen, onClose, form, setForm, onSubmit, isEditing }: EventModalProps) {
   const sharing = SHARING[form.sharingState as SharingState] ?? SHARING.private
   return (
     <Modal isOpen={isOpen} onClose={onClose} isCentered>
       <ModalOverlay bg="blackAlpha.500" backdropFilter="blur(2px)" />
       <ModalContent mx={4}>
-        <ModalHeader fontFamily="heading">予定を追加</ModalHeader>
+        <ModalHeader fontFamily="heading">{isEditing ? '予定を編集' : '予定を追加'}</ModalHeader>
         <ModalCloseButton borderRadius="full" />
         <ModalBody>
           <VStack spacing={4} align="stretch">
@@ -150,7 +151,7 @@ export function EventModal({ isOpen, onClose, form, setForm, onSubmit }: EventMo
             onClick={onSubmit}
             isDisabled={!form.name || !form.startDate || (!form.isAllDay && !form.startTime)}
           >
-            作成する
+            {isEditing ? '保存する' : '作成する'}
           </Button>
         </ModalFooter>
       </ModalContent>

--- a/src/components/Calendar/MonthView.tsx
+++ b/src/components/Calendar/MonthView.tsx
@@ -16,11 +16,12 @@ interface MonthViewProps {
   events: EventRow[]
   now: Date
   onDayClick: (day: Date) => void
+  onEventClick: (ev: EventRow) => void
 }
 
 const MAX_CHIPS = 3
 
-export function MonthView({ anchor, events, now, onDayClick }: MonthViewProps) {
+export function MonthView({ anchor, events, now, onDayClick, onEventClick }: MonthViewProps) {
   const days = monthGridDays(anchor)
 
   return (
@@ -110,6 +111,12 @@ export function MonthView({ anchor, events, now, onDayClick }: MonthViewProps) {
                       px={1}
                       h="18px"
                       overflow="hidden"
+                      cursor="pointer"
+                      _hover={{ bg: ev.isAllDay ? style.bg : 'gray.100' }}
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        onEventClick(ev)
+                      }}
                     >
                       {!ev.isAllDay && (
                         <Box boxSize="6px" borderRadius="full" bg={style.dot} flexShrink={0} />

--- a/src/components/Calendar/TimeGridView.tsx
+++ b/src/components/Calendar/TimeGridView.tsx
@@ -24,6 +24,7 @@ interface TimeGridViewProps {
   currentUserId: string | undefined
   onSlotClick: (day: Date, minute: number) => void
   onAllDayClick: (day: Date) => void
+  onEventClick: (ev: EventRow) => void
   onDelete: (id: string) => void
 }
 
@@ -34,6 +35,7 @@ export function TimeGridView({
   currentUserId,
   onSlotClick,
   onAllDayClick,
+  onEventClick,
   onDelete,
 }: TimeGridViewProps) {
   const scrollRef = useRef<HTMLDivElement>(null)
@@ -147,7 +149,11 @@ export function TimeGridView({
                           borderRadius="sm"
                           px={1.5}
                           py={0.5}
-                          onClick={(e) => e.stopPropagation()}
+                          cursor="pointer"
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            onEventClick(ev)
+                          }}
                         >
                           <Text fontSize="xs" fontWeight="600" color={style.text} noOfLines={1}>
                             {ev.name}
@@ -271,10 +277,13 @@ export function TimeGridView({
                           px={1.5}
                           py={1}
                           overflow="hidden"
-                          cursor="default"
+                          cursor="pointer"
                           transition="filter 0.1s"
                           _hover={{ filter: 'brightness(0.97)', zIndex: 2 }}
-                          onClick={(e) => e.stopPropagation()}
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            onEventClick(ev)
+                          }}
                         >
                           <Flex justify="space-between" align="start" gap={1}>
                             <Text

--- a/src/components/Calendar/calendarUtils.ts
+++ b/src/components/Calendar/calendarUtils.ts
@@ -130,6 +130,30 @@ export const EMPTY_FORM: EventForm = {
   sharingState: 'private',
 }
 
+// Local "HH:MM" (avoids the UTC shift of toISOString / getUTCHours).
+function toTimeInput(d: Date) {
+  return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`
+}
+
+// EventRow → EventForm, ready to pre-fill the modal for editing.
+// All-day events store an exclusive end (start-day + 1), so subtract a day to
+// recover the inclusive end date the user originally picked.
+export function eventToForm(ev: EventRow): EventForm {
+  const start = new Date(ev.startAt)
+  const end = new Date(ev.endAt)
+  const endInclusive = ev.isAllDay ? addDays(end, -1) : end
+  return {
+    name: ev.name,
+    isAllDay: ev.isAllDay,
+    startDate: toDateInput(start),
+    startTime: ev.isAllDay ? '' : toTimeInput(start),
+    endDate: toDateInput(endInclusive),
+    endTime: ev.isAllDay ? '' : toTimeInput(end),
+    eventLocation: ev.eventLocation ?? '',
+    sharingState: ev.sharingState,
+  }
+}
+
 export type Positioned = {
   ev: EventRow
   start: number // minutes from midnight (clamped to this day)

--- a/src/components/Chat/ChatTab.tsx
+++ b/src/components/Chat/ChatTab.tsx
@@ -1,0 +1,252 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  Box,
+  Flex,
+  Heading,
+  Text,
+  HStack,
+  VStack,
+  Avatar,
+  Input,
+  IconButton,
+  Select,
+  Spinner,
+  Center,
+} from '@chakra-ui/react'
+import { ArrowUpIcon } from '@chakra-ui/icons'
+import { supabase } from '../../lib/supabase'
+import { useAuth } from '../../hooks/useAuth'
+import { Card } from '../ui/Card'
+import type { Database } from '../../types/database'
+
+type MessageRow = Database['public']['Tables']['team_messages']['Row']
+
+function formatStamp(iso: string | null) {
+  if (!iso) return ''
+  const d = new Date(iso)
+  return d.toLocaleString('ja-JP', {
+    month: 'numeric',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+export default function ChatTab() {
+  const { user, teams } = useAuth()
+  const [teamId, setTeamId] = useState<string | null>(teams[0]?.id ?? null)
+  const [messages, setMessages] = useState<MessageRow[]>([])
+  const [memberNames, setMemberNames] = useState<Map<string, string>>(new Map())
+  const [loading, setLoading] = useState(false)
+  const [draft, setDraft] = useState('')
+  const [sending, setSending] = useState(false)
+  const bottomRef = useRef<HTMLDivElement>(null)
+
+  // Keep a valid selected team as membership changes.
+  useEffect(() => {
+    if (teams.length === 0) {
+      setTeamId(null)
+    } else if (!teamId || !teams.some((t) => t.id === teamId)) {
+      setTeamId(teams[0].id)
+    }
+  }, [teams, teamId])
+
+  const fetchMembers = useCallback(async (tid: string) => {
+    const { data: rows } = await supabase
+      .from('user_teams')
+      .select('userId')
+      .eq('teamId', tid)
+    const ids = Array.from(new Set((rows ?? []).map((r) => r.userId)))
+    if (ids.length === 0) return setMemberNames(new Map())
+    const { data: users } = await supabase
+      .from('users')
+      .select('id, displayName')
+      .in('id', ids)
+    setMemberNames(new Map((users ?? []).map((u) => [u.id, u.displayName])))
+  }, [])
+
+  const fetchMessages = useCallback(async (tid: string) => {
+    setLoading(true)
+    try {
+      const { data } = await supabase
+        .from('team_messages')
+        .select('*')
+        .eq('teamId', tid)
+        .order('createdAt', { ascending: true })
+      setMessages(data ?? [])
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  // Load messages + members, and subscribe to live inserts for this team.
+  useEffect(() => {
+    if (!teamId) {
+      setMessages([])
+      return
+    }
+    void fetchMembers(teamId)
+    void fetchMessages(teamId)
+
+    const channel = supabase
+      .channel(`team_messages:${teamId}`)
+      .on(
+        'postgres_changes',
+        { event: 'INSERT', schema: 'public', table: 'team_messages', filter: `teamId=eq.${teamId}` },
+        (payload) => {
+          setMessages((prev) => {
+            const next = payload.new as MessageRow
+            if (prev.some((m) => m.id === next.id)) return prev
+            return [...prev, next]
+          })
+        },
+      )
+      .subscribe()
+
+    return () => {
+      void supabase.removeChannel(channel)
+    }
+  }, [teamId, fetchMembers, fetchMessages])
+
+  // Auto-scroll to the newest message.
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [messages])
+
+  const nameOf = useCallback(
+    (id: string) => (id === user?.id ? 'あなた' : memberNames.get(id) ?? 'メンバー'),
+    [memberNames, user?.id],
+  )
+
+  async function handleSend() {
+    const body = draft.trim()
+    if (!body || !teamId || !user) return
+    setSending(true)
+    try {
+      const { error } = await supabase
+        .from('team_messages')
+        .insert({ teamId, userId: user.id, body })
+      if (error) {
+        console.error('send message error', error)
+        return
+      }
+      setDraft('')
+      // Realtime will append, but refetch as a fallback if it doesn't arrive.
+      void fetchMessages(teamId)
+    } finally {
+      setSending(false)
+    }
+  }
+
+  const selectedTeamName = useMemo(
+    () => teams.find((t) => t.id === teamId)?.teamName ?? '',
+    [teams, teamId],
+  )
+
+  if (teams.length === 0) {
+    return (
+      <Card>
+        <Text color="gray.500" textAlign="center" py={6}>
+          チームに参加するとチャットが利用できます。「チーム」タブから作成・参加してください。
+        </Text>
+      </Card>
+    )
+  }
+
+  return (
+    <VStack align="stretch" spacing={4}>
+      <Flex justify="space-between" align={{ base: 'stretch', md: 'center' }} direction={{ base: 'column', md: 'row' }} gap={3}>
+        <Box>
+          <Heading size="lg" letterSpacing="tight">
+            チャット
+          </Heading>
+          <Text color="gray.600" mt={1}>
+            {selectedTeamName} のメンバーとリアルタイムにやり取りできます。
+          </Text>
+        </Box>
+        {teams.length > 1 && (
+          <Box minW="200px">
+            <Select value={teamId ?? ''} onChange={(e) => setTeamId(e.target.value)}>
+              {teams.map((t) => (
+                <option key={t.id} value={t.id}>
+                  {t.teamName}
+                </option>
+              ))}
+            </Select>
+          </Box>
+        )}
+      </Flex>
+
+      <Card p={0} overflow="hidden">
+        <Box h="calc(100vh - 340px)" minH="320px" overflowY="auto" px={4} py={4}>
+          {loading ? (
+            <Center h="100%">
+              <Spinner color="primary.500" thickness="3px" />
+            </Center>
+          ) : messages.length === 0 ? (
+            <Center h="100%">
+              <Text color="gray.400">まだメッセージがありません。最初の一言を送ってみましょう。</Text>
+            </Center>
+          ) : (
+            <VStack align="stretch" spacing={3}>
+              {messages.map((m) => {
+                const mine = m.userId === user?.id
+                return (
+                  <Flex key={m.id} justify={mine ? 'flex-end' : 'flex-start'} gap={2}>
+                    {!mine && <Avatar size="sm" name={nameOf(m.userId)} bg="primary.500" color="white" />}
+                    <Box maxW="72%">
+                      {!mine && (
+                        <Text fontSize="xs" color="gray.500" mb={0.5} ml={1}>
+                          {nameOf(m.userId)}
+                        </Text>
+                      )}
+                      <Box
+                        bg={mine ? 'primary.500' : 'gray.100'}
+                        color={mine ? 'white' : 'gray.900'}
+                        px={3}
+                        py={2}
+                        borderRadius="2xl"
+                        borderTopRightRadius={mine ? 'sm' : '2xl'}
+                        borderTopLeftRadius={mine ? '2xl' : 'sm'}
+                      >
+                        <Text fontSize="sm" whiteSpace="pre-wrap" wordBreak="break-word">
+                          {m.body}
+                        </Text>
+                      </Box>
+                      <Text fontSize="10px" color="gray.400" mt={0.5} textAlign={mine ? 'right' : 'left'}>
+                        {formatStamp(m.createdAt)}
+                      </Text>
+                    </Box>
+                  </Flex>
+                )
+              })}
+              <div ref={bottomRef} />
+            </VStack>
+          )}
+        </Box>
+
+        <HStack p={3} borderTop="1px solid" borderColor="gray.200" bg="paper-2" spacing={2}>
+          <Input
+            placeholder="メッセージを入力"
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && !e.shiftKey) {
+                e.preventDefault()
+                void handleSend()
+              }
+            }}
+          />
+          <IconButton
+            aria-label="送信"
+            icon={<ArrowUpIcon />}
+            colorScheme="primary"
+            isLoading={sending}
+            isDisabled={!draft.trim()}
+            onClick={() => void handleSend()}
+          />
+        </HStack>
+      </Card>
+    </VStack>
+  )
+}

--- a/src/components/Layout/MainLayout.tsx
+++ b/src/components/Layout/MainLayout.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import CalendarTab from '../Calendar/CalendarTab'
 import MapTab from '../Map/MapTab'
 import TeamsTab from '../Team/TeamsTab'
+import ChatTab from '../Chat/ChatTab'
 import {
   Box,
   Flex,
@@ -67,6 +68,7 @@ export function MainLayout() {
                 {[
                   { icon: '🗓', label: 'カレンダー' },
                   { icon: '🗺', label: 'マップ' },
+                  { icon: '💬', label: 'チャット' },
                   { icon: '👥', label: 'チーム' },
                 ].map((t) => (
                   <Tab
@@ -142,6 +144,9 @@ export function MainLayout() {
             </TabPanel>
             <TabPanel p={0}>
               <MapTab />
+            </TabPanel>
+            <TabPanel p={0}>
+              <ChatTab />
             </TabPanel>
             <TabPanel p={0}>
               <TeamsTab />

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -105,6 +105,30 @@ export type Database = {
         }
         Relationships: []
       }
+      team_messages: {
+        Row: {
+          id: string
+          teamId: string
+          userId: string
+          body: string
+          createdAt: string | null
+        }
+        Insert: {
+          id?: string
+          teamId: string
+          userId: string
+          body: string
+          createdAt?: string | null
+        }
+        Update: {
+          id?: string
+          teamId?: string
+          userId?: string
+          body?: string
+          createdAt?: string | null
+        }
+        Relationships: []
+      }
       events: {
         Row: {
           id: string

--- a/supabase/migrations/0003_team_messages.sql
+++ b/supabase/migrations/0003_team_messages.sql
@@ -1,0 +1,52 @@
+-- ============================================================
+-- 0003_team_messages.sql
+-- チーム内チャット（team_messages）
+-- ============================================================
+
+-- ----------------------------------------------------------
+-- TABLE
+-- ----------------------------------------------------------
+CREATE TABLE IF NOT EXISTS team_messages (
+  id          uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  "teamId"    uuid        NOT NULL REFERENCES teams(id) ON DELETE CASCADE,
+  "userId"    uuid        NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  body        text        NOT NULL CHECK (char_length(body) BETWEEN 1 AND 2000),
+  "createdAt" timestamptz DEFAULT now()
+);
+
+-- ----------------------------------------------------------
+-- INDEXES
+-- ----------------------------------------------------------
+CREATE INDEX IF NOT EXISTS idx_team_messages_team_id ON team_messages ("teamId", "createdAt");
+CREATE INDEX IF NOT EXISTS idx_team_messages_user_id ON team_messages ("userId");
+
+-- ----------------------------------------------------------
+-- REALTIME
+-- ----------------------------------------------------------
+ALTER PUBLICATION supabase_realtime ADD TABLE team_messages;
+
+-- ----------------------------------------------------------
+-- ROW LEVEL SECURITY
+-- ----------------------------------------------------------
+ALTER TABLE team_messages ENABLE ROW LEVEL SECURITY;
+
+-- 所属チームのメッセージのみ閲覧可
+CREATE POLICY "team_messages_select" ON team_messages
+  FOR SELECT USING (
+    "teamId" IN (
+      SELECT "teamId" FROM user_teams WHERE "userId" = auth.uid()
+    )
+  );
+
+-- 自分の投稿のみ、かつ所属チームへのみ送信可
+CREATE POLICY "team_messages_insert" ON team_messages
+  FOR INSERT WITH CHECK (
+    "userId" = auth.uid()
+    AND "teamId" IN (
+      SELECT "teamId" FROM user_teams WHERE "userId" = auth.uid()
+    )
+  );
+
+-- 自分の投稿のみ削除可
+CREATE POLICY "team_messages_delete" ON team_messages
+  FOR DELETE USING ("userId" = auth.uid());


### PR DESCRIPTION
## 概要
2つの機能を追加しました。

## 1. 予定の編集
- 予定ブロック（週/日/月ビュー）をクリックすると編集モーダルが開く
- `handleCreate` を insert/update を分岐する `handleSubmit` に統合
- `eventToForm()` で保存済みの値をフォームへ復元 — **編集時に公開範囲が指定どおりにマッチ**（終日イベントの終了日も元の入力に戻す）
- EventModal は編集時にタイトル「予定を編集」・ボタン「保存する」へ

## 2. チーム内チャット
- `team_messages` テーブル（`teamId`/`userId`/`body`/`createdAt`）+ RLS + Realtime（migration `0003`）
- 「💬 チャット」タブを追加（[ChatTab](src/components/Chat/ChatTab.tsx)）
- チーム別のリアルタイムチャット（自分=右/インディゴ吹き出し、相手=左+アバター+表示名+時刻）
- 複数チーム所属時は切替セレクト、未所属時は案内表示、Enter 送信・自動スクロール

## レビュアーへの補足（重要）
- **migration `0003` はリモート DB に適用済み**です。適用時、リモートのマイグレーション履歴が空で `db push` が破壊的な `0001`（全テーブル DROP）から再適用しようとしたため、`migration repair --status applied 0001 0002` で履歴を同期してから **0003 のみ**を安全に push しました。
- チャットの閲覧/送信は RLS で所属チーム限定。`team_messages` は Realtime 有効化済み。

## 確認
- [x] `npm run build` が通る
- [x] team_messages テーブル作成を確認（リモート）
- [ ] 動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)