### PR TITLE
feat(calendar): チームごとのフィルタ（プルダウンチェックリスト）

### DIFF
--- a/src/components/Calendar/CalendarSidebar.tsx
+++ b/src/components/Calendar/CalendarSidebar.tsx
@@ -18,7 +18,7 @@ import {
   SimpleGrid,
   useDisclosure,
 } from '@chakra-ui/react'
-import { ChevronLeftIcon, ChevronRightIcon, AddIcon } from '@chakra-ui/icons'
+import { ChevronLeftIcon, ChevronRightIcon, ChevronDownIcon, AddIcon } from '@chakra-ui/icons'
 import { Button } from '../ui/Button'
 import {
   WEEKDAYS,
@@ -30,6 +30,8 @@ import {
   type SharingState,
 } from './calendarUtils'
 
+type SidebarTeam = { id: string; teamName: string }
+
 interface CalendarSidebarProps {
   anchor: Date
   now: Date
@@ -37,6 +39,9 @@ interface CalendarSidebarProps {
   onCreate: () => void
   filters: Set<SharingState>
   onToggleFilter: (s: SharingState) => void
+  teams: SidebarTeam[]
+  hiddenTeams: Set<string>
+  onToggleTeam: (teamId: string) => void
 }
 
 export function CalendarSidebar({
@@ -46,6 +51,9 @@ export function CalendarSidebar({
   onCreate,
   filters,
   onToggleFilter,
+  teams,
+  hiddenTeams,
+  onToggleTeam,
 }: CalendarSidebarProps) {
   // The month shown in the mini calendar (independent of the main anchor).
   const [miniMonth, setMiniMonth] = useState(() => new Date(anchor))
@@ -256,6 +264,52 @@ export function CalendarSidebar({
           ))}
         </VStack>
       </Box>
+
+      {/* Team filter — a pull-down checklist of the user's teams */}
+      {teams.length > 0 && (
+        <Box mt={6}>
+          <Text fontSize="xs" fontWeight="bold" color="gray.500" mb={2} letterSpacing="wide">
+            チーム
+          </Text>
+          <Popover placement="bottom-start">
+            <PopoverTrigger>
+              <Button
+                variant="secondary"
+                w="full"
+                justifyContent="space-between"
+                rightIcon={<ChevronDownIcon />}
+                fontWeight="500"
+              >
+                <Text fontSize="sm" noOfLines={1}>
+                  {teams.length - hiddenTeams.size === teams.length
+                    ? 'すべてのチーム'
+                    : `${teams.length - hiddenTeams.size}/${teams.length} チーム`}
+                </Text>
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent w="240px">
+              <PopoverArrow />
+              <PopoverBody>
+                <VStack align="stretch" spacing={2} maxH="240px" overflowY="auto">
+                  {teams.map((t) => (
+                    <Checkbox
+                      key={t.id}
+                      isChecked={!hiddenTeams.has(t.id)}
+                      onChange={() => onToggleTeam(t.id)}
+                      colorScheme="primary"
+                      size="sm"
+                    >
+                      <Text fontSize="sm" color="gray.700" noOfLines={1}>
+                        {t.teamName}
+                      </Text>
+                    </Checkbox>
+                  ))}
+                </VStack>
+              </PopoverBody>
+            </PopoverContent>
+          </Popover>
+        </Box>
+      )}
     </Box>
   )
 }

--- a/src/components/Calendar/CalendarTab.tsx
+++ b/src/components/Calendar/CalendarTab.tsx
@@ -51,6 +51,8 @@ export default function CalendarTab() {
   const [filters, setFilters] = useState<Set<SharingState>>(
     () => new Set<SharingState>(['private', 'friends', 'team']),
   )
+  // Teams the user has *unchecked* in the team filter. Empty = show all teams.
+  const [hiddenTeams, setHiddenTeams] = useState<Set<string>>(() => new Set())
 
   const { isOpen, onOpen, onClose } = useDisclosure()
   const toast = useToast()
@@ -114,8 +116,11 @@ export default function CalendarTab() {
   }
 
   const visibleEvents = useMemo(
-    () => events.filter((e) => filters.has(e.sharingState as SharingState)),
-    [events, filters],
+    () =>
+      events.filter(
+        (e) => filters.has(e.sharingState as SharingState) && !hiddenTeams.has(e.teamId),
+      ),
+    [events, filters, hiddenTeams],
   )
 
   const days = useMemo(() => {
@@ -143,6 +148,15 @@ export default function CalendarTab() {
       const next = new Set(prev)
       if (next.has(s)) next.delete(s)
       else next.add(s)
+      return next
+    })
+  }
+
+  function toggleTeam(teamId: string) {
+    setHiddenTeams((prev) => {
+      const next = new Set(prev)
+      if (next.has(teamId)) next.delete(teamId)
+      else next.add(teamId)
       return next
     })
   }
@@ -284,6 +298,9 @@ export default function CalendarTab() {
         onCreate={openBlank}
         filters={filters}
         onToggleFilter={toggleFilter}
+        teams={teams}
+        hiddenTeams={hiddenTeams}
+        onToggleTeam={toggleTeam}
       />
 
       <Box flex={1} minW={0}>


### PR DESCRIPTION
## 概要
カレンダーで**チームごとに表示をON/OFF**できるようにしました。サイドバーの「チーム」プルダウン（チェックリスト）から所属チームを個別に選択できます。

## 変更点
- **CalendarSidebar**: 「チーム」セクションを追加。Popover を開くと所属チームのチェックリストが出て、個別に表示/非表示を切り替え。トリガーには選択数（例: `2/3 チーム` / `すべてのチーム`）を表示。
- **CalendarTab**: `hiddenTeams`（未選択チームの集合）で `visibleEvents` を絞り込み。既存の公開範囲フィルタ（自分のみ/友だち/チーム）とAND。

## 備考
- チームが0件のときはセクション非表示。
- ビルド・Lint クリーン。

## マップの「Team時チェックボックス」について（別途相談）
`locations` は1ユーザー1行・単一 `sharingState` のため、**特定チームだけに位置共有するにはスキーマ変更が必要**です。この PR には含めず、方針を確認後に対応予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)