### PR TITLE
feat(map): 位置共有を特定チーム単位で選択

### DIFF
--- a/src/components/Map/MapTab.tsx
+++ b/src/components/Map/MapTab.tsx
@@ -1,6 +1,18 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { MapContainer, TileLayer, Marker, Popup, useMap, useMapEvents } from 'react-leaflet'
-import { Box, Button, Flex, HStack, Text, Select, VStack, Alert, AlertIcon, Badge } from '@chakra-ui/react'
+import {
+  Box,
+  Button,
+  Checkbox,
+  Flex,
+  HStack,
+  Text,
+  Select,
+  VStack,
+  Alert,
+  AlertIcon,
+  Badge,
+} from '@chakra-ui/react'
 import { supabase } from '../../lib/supabase'
 import { useAuth } from '../../hooks/useAuth'
 import { useRealtimeLocations } from '../../hooks/useRealtime'
@@ -78,6 +90,8 @@ export default function MapTab() {
   const { user, teams } = useAuth()
   const { locations, fetchLocations } = useRealtimeLocations()
   const [sharingState, setSharingState] = useState<LocationRow['sharingState']>('private')
+  // Teams to share the location with when sharingState === 'team'. Empty = all teams.
+  const [sharedTeams, setSharedTeams] = useState<Set<string>>(new Set())
   const [currentPosition, setCurrentPosition] = useState<LatLng | null>(null)
   const [permissionError, setPermissionError] = useState<string | null>(null)
   const [saving, setSaving] = useState(false)
@@ -160,7 +174,7 @@ export default function MapTab() {
   }, [user])
 
   const upsertLocation = useCallback(
-    async (position: LatLng, state: LocationRow['sharingState']) => {
+    async (position: LatLng, state: LocationRow['sharingState'], sharedTeamIds: string[]) => {
       if (!user) return
       setSaving(true)
       try {
@@ -172,6 +186,8 @@ export default function MapTab() {
               lat: position.lat,
               lng: position.lng,
               sharingState: state,
+              // Only meaningful for 'team'; keep empty otherwise.
+              sharedTeamIds: state === 'team' ? sharedTeamIds : [],
             },
             { onConflict: 'userId' },
           )
@@ -191,9 +207,17 @@ export default function MapTab() {
 
   const handleRefresh = useCallback(async () => {
     if (!user || !currentPosition) return
-    await upsertLocation(currentPosition, sharingState)
+    await upsertLocation(currentPosition, sharingState, Array.from(sharedTeams))
     await Promise.all([fetchLocations(), fetchTeamMembers()])
-  }, [user, currentPosition, sharingState, upsertLocation, fetchLocations, fetchTeamMembers])
+  }, [
+    user,
+    currentPosition,
+    sharingState,
+    sharedTeams,
+    upsertLocation,
+    fetchLocations,
+    fetchTeamMembers,
+  ])
 
   const currentPositionLabel = currentPosition
     ? `${currentPosition.lat.toFixed(5)}, ${currentPosition.lng.toFixed(5)}`
@@ -234,6 +258,39 @@ export default function MapTab() {
             <option value="friends">friends（友達）</option>
             <option value="team">team（チーム）</option>
           </Select>
+
+          {/* When sharing to teams, pick which teams (none = all your teams) */}
+          {sharingState === 'team' && teams.length > 0 && (
+            <Box mt={3}>
+              <Text mb={1} fontSize="sm" fontWeight="medium">
+                共有するチーム
+              </Text>
+              <Text mb={2} fontSize="xs" color="gray.500">
+                未選択の場合は所属する全チームに共有します。
+              </Text>
+              <VStack align="stretch" spacing={2}>
+                {teams.map((t) => (
+                  <Checkbox
+                    key={t.id}
+                    isChecked={sharedTeams.has(t.id)}
+                    onChange={() =>
+                      setSharedTeams((prev) => {
+                        const next = new Set(prev)
+                        if (next.has(t.id)) next.delete(t.id)
+                        else next.add(t.id)
+                        return next
+                      })
+                    }
+                  >
+                    <Text fontSize="sm">{t.teamName}</Text>
+                  </Checkbox>
+                ))}
+              </VStack>
+              <Text mt={2} fontSize="xs" color="gray.400">
+                変更後は「マップを更新」で反映されます。
+              </Text>
+            </Box>
+          )}
         </Box>
       </Flex>
 

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -174,6 +174,7 @@ export type Database = {
           lat: number | null
           lng: number | null
           sharingState: 'private' | 'friends' | 'team'
+          sharedTeamIds: string[]
           updatedAt: string | null
         }
         Insert: {
@@ -181,6 +182,7 @@ export type Database = {
           lat?: number | null
           lng?: number | null
           sharingState?: 'private' | 'friends' | 'team'
+          sharedTeamIds?: string[]
           updatedAt?: string | null
         }
         Update: {
@@ -188,6 +190,7 @@ export type Database = {
           lat?: number | null
           lng?: number | null
           sharingState?: 'private' | 'friends' | 'team'
+          sharedTeamIds?: string[]
           updatedAt?: string | null
         }
         Relationships: []

--- a/supabase/migrations/0004_location_team_sharing.sql
+++ b/supabase/migrations/0004_location_team_sharing.sql
@@ -1,0 +1,45 @@
+-- ============================================================
+-- Per-team location sharing.
+--
+-- Adds locations."sharedTeamIds": when sharingState = 'team', the location is
+-- visible only to members of the listed teams. An empty list keeps the previous
+-- behaviour (shared with every team the owner belongs to), so existing rows are
+-- unaffected.
+-- ============================================================
+
+ALTER TABLE locations
+  ADD COLUMN "sharedTeamIds" uuid[] NOT NULL DEFAULT '{}';
+
+-- Rebuild the SELECT policy so the 'team' case respects sharedTeamIds.
+DROP POLICY IF EXISTS "locations_select" ON locations;
+
+CREATE POLICY "locations_select" ON locations
+  FOR SELECT USING (
+    -- private: 本人のみ
+    ("sharingState" = 'private' AND "userId" = auth.uid())
+    OR
+    -- friends: 自分、または自分を friendId に持つ友達関係があるユーザー
+    ("sharingState" = 'friends' AND (
+      "userId" = auth.uid()
+      OR "userId" IN (
+        SELECT "friendId" FROM user_friends WHERE "userId" = auth.uid()
+      )
+    ))
+    OR
+    -- team: 本人、または「共有先チーム」に所属するメンバー
+    --       sharedTeamIds が空の場合は従来どおり所属する全チームへ共有
+    ("sharingState" = 'team' AND (
+      "userId" = auth.uid()
+      OR EXISTS (
+        SELECT 1
+        FROM   user_teams owner_ut
+        JOIN   user_teams viewer_ut ON owner_ut."teamId" = viewer_ut."teamId"
+        WHERE  owner_ut."userId"  = locations."userId"
+          AND  viewer_ut."userId" = auth.uid()
+          AND  (
+            cardinality(locations."sharedTeamIds") = 0
+            OR owner_ut."teamId" = ANY(locations."sharedTeamIds")
+          )
+      )
+    ))
+  );


### PR DESCRIPTION
## 概要
マップの位置共有で、共有範囲が **team** のときに**共有先チームをチェックボックスで選択**できるようにしました（未選択なら従来どおり所属する全チームへ共有）。

## 変更点
- **migration `0004_location_team_sharing.sql`**:
  - `locations` に `sharedTeamIds uuid[] NOT NULL DEFAULT '{}'` を追加
  - `locations_select` の team 句を「共有先チームに所属するメンバーのみ」に変更。`sharedTeamIds` が空なら従来どおり所属全チームへ共有（既存行は影響なし）
- **database.ts**: `locations` 型に `sharedTeamIds` を追加
- **MapTab**: 共有範囲=team のときチーム一覧のチェックリストを表示。「マップを更新」で `sharedTeamIds` を保存

## ⚠️ マージ後に必要
マイグレーション `0004` の適用が必要です。
- 本番: `npx supabase db push`
- ローカル: `npx supabase db reset`
- 反映後にキャッシュが古い場合: `NOTIFY pgrst, 'reload schema';`

## 補足
- 可視性は RLS でサーバー側に強制されるため、クライアントは `sharedTeamIds` を保存するだけ。
- ビルド・Lint クリーン。

🤖 Generated with [Claude Code](https://claude.com/claude-code)