### PR TITLE
fix(db): マイグレーション0004重複の解消＋SECURITY DEFINER関数の堅牢化 (#43, #44)

### DIFF
--- a/supabase/migrations/0007_location_team_sharing.sql
+++ b/supabase/migrations/0007_location_team_sharing.sql
@@ -5,10 +5,13 @@
 -- visible only to members of the listed teams. An empty list keeps the previous
 -- behaviour (shared with every team the owner belongs to), so existing rows are
 -- unaffected.
+--
+-- NOTE: renamed from 0004 (which collided with 0004_team_messages_retention) and
+-- made idempotent so it is safe to (re)apply regardless of current DB state.
 -- ============================================================
 
 ALTER TABLE locations
-  ADD COLUMN "sharedTeamIds" uuid[] NOT NULL DEFAULT '{}';
+  ADD COLUMN IF NOT EXISTS "sharedTeamIds" uuid[] NOT NULL DEFAULT '{}';
 
 -- Rebuild the SELECT policy so the 'team' case respects sharedTeamIds.
 DROP POLICY IF EXISTS "locations_select" ON locations;

--- a/supabase/migrations/0008_harden_definer_functions.sql
+++ b/supabase/migrations/0008_harden_definer_functions.sql
@@ -1,0 +1,75 @@
+-- ============================================================
+-- 0008_harden_definer_functions.sql
+-- SECURITY DEFINER 関数のセキュリティ強化:
+--   * SET search_path を固定（search_path 注入による権限昇格を防止）
+--   * 実行権限を authenticated に限定（PUBLIC からは REVOKE）
+--
+-- 関数本体は既存（0004/0005）と同一。CREATE OR REPLACE で冪等。
+-- delete_own_account（0006）は既に対策済みのため対象外。
+-- ============================================================
+
+-- ---------- フレンド申請の承認（双方向 user_friends を作成） ----------
+CREATE OR REPLACE FUNCTION accept_friend_request(request_id uuid)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_catalog
+AS $$
+DECLARE
+  req friend_requests%ROWTYPE;
+BEGIN
+  SELECT * INTO req FROM friend_requests WHERE id = request_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'request not found';
+  END IF;
+  -- 承認できるのは受信者本人のみ
+  IF req."addresseeId" <> auth.uid() THEN
+    RAISE EXCEPTION 'not authorized';
+  END IF;
+
+  UPDATE friend_requests SET status = 'accepted' WHERE id = request_id;
+
+  INSERT INTO user_friends ("userId", "friendId")
+  VALUES (req."requesterId", req."addresseeId"), (req."addresseeId", req."requesterId")
+  ON CONFLICT ("userId", "friendId") DO NOTHING;
+END;
+$$;
+
+-- ---------- フレンド解除（双方向 user_friends と申請を削除） ----------
+CREATE OR REPLACE FUNCTION remove_friend(other_id uuid)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_catalog
+AS $$
+BEGIN
+  DELETE FROM user_friends
+  WHERE ("userId" = auth.uid() AND "friendId" = other_id)
+     OR ("userId" = other_id AND "friendId" = auth.uid());
+
+  DELETE FROM friend_requests
+  WHERE ("requesterId" = auth.uid() AND "addresseeId" = other_id)
+     OR ("requesterId" = other_id AND "addresseeId" = auth.uid());
+END;
+$$;
+
+-- ---------- 30日より古いチームメッセージの削除（pg_cron から実行） ----------
+CREATE OR REPLACE FUNCTION delete_old_team_messages()
+RETURNS void
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public, pg_catalog
+AS $$
+  DELETE FROM team_messages
+  WHERE "createdAt" < now() - interval '30 days';
+$$;
+
+-- ---------- 実行権限を authenticated に限定 ----------
+REVOKE ALL ON FUNCTION accept_friend_request(uuid) FROM public;
+GRANT EXECUTE ON FUNCTION accept_friend_request(uuid) TO authenticated;
+
+REVOKE ALL ON FUNCTION remove_friend(uuid) FROM public;
+GRANT EXECUTE ON FUNCTION remove_friend(uuid) TO authenticated;
+
+-- delete_old_team_messages は cron からのみ呼ぶため一般ユーザーには付与しない。
+REVOKE ALL ON FUNCTION delete_old_team_messages() FROM public;


### PR DESCRIPTION
## 概要
リリースブロッカーの DB 課題 2 件を修正します。

### #43 マイグレーション番号 0004 の重複
- `0004_location_team_sharing.sql` → **`0007_location_team_sharing.sql`** にリネーム（重複解消）
- `ADD COLUMN IF NOT EXISTS` に変更し**冪等化**（再適用しても安全）

### #44 SECURITY DEFINER 関数の堅牢化（新規 `0008_harden_definer_functions.sql`）
- `accept_friend_request` / `remove_friend` / `delete_old_team_messages` を **`SET search_path = public, pg_catalog`** 付きで `CREATE OR REPLACE`
- `REVOKE ALL ... FROM public` ＋ ユーザー向け関数は `GRANT EXECUTE ... TO authenticated`
- 関数本体は既存と同一・冪等

## ⚠️ 適用時の確認（重要）
0004 重複により、環境によっては **`0004_team_messages_retention`（30日自動削除の cron）が未適用**の可能性があります。マージ後に以下で状態確認・適用してください。
\`\`\`bash
npx supabase migration list           # 適用状況を確認
npx supabase db push                  # 0007/0008 を適用
\`\`\`
- もし cron ジョブ `delete-old-team-messages` が無ければ、`0004_team_messages_retention.sql` を手動再適用するか `supabase migration repair` で履歴を整合してください（このマイグレーションは冪等です）。
- 反映後にキャッシュが古い場合: \`NOTIFY pgrst, 'reload schema';\`

## 補足
- 変更は SQL マイグレーションのみ（アプリ側の型・コードは変更なし）。

Closes #43
Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)