### PR TITLE
feat(calendar): カレンダーの表示高さを拡大

### DIFF
--- a/src/components/Calendar/MonthView.tsx
+++ b/src/components/Calendar/MonthView.tsx
@@ -42,7 +42,7 @@ export function MonthView({ anchor, events, now, onDayClick, onEventClick }: Mon
       </Grid>
 
       {/* 6-week grid */}
-      <Grid templateColumns="repeat(7, 1fr)" templateRows="repeat(6, 1fr)" h={{ base: 'auto', md: 'calc(100vh - 280px)' }}>
+      <Grid templateColumns="repeat(7, 1fr)" templateRows="repeat(6, 1fr)" h={{ base: 'auto', md: 'calc(100vh - 220px)' }}>
         {days.map((d) => {
           const inMonth = isSameMonth(d, anchor)
           const today = isSameDay(d, now)

--- a/src/components/Calendar/TimeGridView.tsx
+++ b/src/components/Calendar/TimeGridView.tsx
@@ -65,7 +65,7 @@ export function TimeGridView({
             ref={scrollRef}
             direction="column"
             overflowY="auto"
-            maxH={{ base: '60vh', md: 'calc(100vh - 320px)' }}
+            maxH={{ base: '74vh', md: 'calc(100vh - 240px)' }}
           >
             {/* Sticky header: day labels + all-day row stay visible while scrolling */}
             <Box position="sticky" top={0} zIndex={4} bg="paper-2">


### PR DESCRIPTION
## 概要
カレンダーの表示が短いとの要望を受け、時間グリッド（週/日）と月表示の高さを広げました。

- **TimeGridView**: `maxH` を `calc(100vh - 320px)` → `calc(100vh - 240px)`、モバイルは `60vh` → `74vh`
- **MonthView**: 高さを `calc(100vh - 280px)` → `calc(100vh - 220px)`

ヘッダーはスクロール領域内で sticky のため、列ズレや固定ヘッダーの挙動は維持されます。ビルドOK。

> もっと伸ばす/抑える場合は、引き算の px（240/220）を調整すれば微調整できます。