### PR TITLE
feat(calendar): カレンダーを画面下部までフィル＋ページスクロール不要に

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,23 @@
+# ============================================================
+# 環境変数のサンプル
+# ------------------------------------------------------------
+# 使い方:
+#   1. このファイルをコピーして「.env」という名前で保存する
+#        cp .env.example .env        (Windows: copy .env.example .env)
+#   2. 下の値を自分の Supabase プロジェクトのものに書き換える
+#   3. npm run dev を再起動する（.env は起動時に読み込まれる）
+#
+# 値の場所: Supabase ダッシュボード → 対象プロジェクト
+#   → Project Settings → API
+#     - Project URL            → VITE_SUPABASE_URL
+#     - Project API keys / anon → VITE_SUPABASE_ANON_KEY
+#
+# 注意:
+#   - 「.env」本体は Git にコミットしない（.gitignore 済み）。
+#   - これが無いと画面が真っ白になる（接続先が分からず起動に失敗するため）。
+#   - 本番(Vercel)では、このファイルではなく Vercel の
+#     Environment Variables に同じ2つを登録する。
+# ============================================================
+
 VITE_SUPABASE_URL=https://your-project-id.supabase.co
 VITE_SUPABASE_ANON_KEY=your-anon-key

--- a/src/components/Calendar/CalendarSidebar.tsx
+++ b/src/components/Calendar/CalendarSidebar.tsx
@@ -72,7 +72,14 @@ export function CalendarSidebar({
   }, [miniMonth])
 
   return (
-    <Box w="260px" flexShrink={0} display={{ base: 'none', lg: 'block' }} pr={6}>
+    <Box
+      w="260px"
+      flexShrink={0}
+      display={{ base: 'none', lg: 'block' }}
+      pr={6}
+      maxH={{ lg: 'calc(100dvh - 136px)' }}
+      overflowY={{ lg: 'auto' }}
+    >
       <Button
         variant="signal"
         leftIcon={<AddIcon boxSize={3} />}

--- a/src/components/Calendar/MonthView.tsx
+++ b/src/components/Calendar/MonthView.tsx
@@ -42,7 +42,7 @@ export function MonthView({ anchor, events, now, onDayClick, onEventClick }: Mon
       </Grid>
 
       {/* 6-week grid */}
-      <Grid templateColumns="repeat(7, 1fr)" templateRows="repeat(6, 1fr)" h={{ base: 'auto', md: 'calc(100vh - 280px)' }}>
+      <Grid templateColumns="repeat(7, 1fr)" templateRows="repeat(6, 1fr)" h={{ base: 'auto', md: 'calc(100dvh - 200px)' }}>
         {days.map((d) => {
           const inMonth = isSameMonth(d, anchor)
           const today = isSameDay(d, now)

--- a/src/components/Calendar/TimeGridView.tsx
+++ b/src/components/Calendar/TimeGridView.tsx
@@ -65,7 +65,7 @@ export function TimeGridView({
             ref={scrollRef}
             direction="column"
             overflowY="auto"
-            maxH={{ base: '60vh', md: 'calc(100vh - 320px)' }}
+            maxH={{ base: '68vh', md: 'calc(100dvh - 200px)' }}
           >
             {/* Sticky header: day labels + all-day row stay visible while scrolling */}
             <Box position="sticky" top={0} zIndex={4} bg="paper-2">


### PR DESCRIPTION
## 概要
「ページ全体をスクロールしたくない」「カレンダーを画面下部まで表示したい」の2点に対応。カレンダー領域をビューポートの残り高さいっぱいに広げ、**内部スクロールのみ／ページ（body）はスクロールしない**ようにしました。

## 変更点
- **TimeGridView / MonthView**: 高さを `calc(100dvh - 200px)` に。時間グリッドはコンテンツが常に画面より高いので、結果として**画面下部までフィル**して内部スクロール。
- **CalendarSidebar**: `maxH=calc(100dvh - 136px)` ＋ `overflowY:auto` でビューポート内に収め、**サイドバーが原因の全体スクロールを解消**（はみ出す分はサイドバー内でスクロール）。
- `100vh` → `100dvh` でモバイルのアドレスバー等による高さ変動にも対応。

## 補足
- オフセット(200/136px)は「ヘッダー64 + メイン余白 + ツールバー」を見込んだ値。微妙に余白が出る/はみ出す場合は数値を微調整します。
- 既存の #58（カレンダー高さ拡大）は本PRが上位互換のため、マージ時はクローズ推奨。
- カレンダーはログイン後表示のため未認証プレビューでは目視確認できていません（アプリ起動は確認済み・ビルドOK）。