### PR TITLE
feat: フレンド申請・メッセージのレート制限（#55）

### DIFF
--- a/src/components/Chat/ChatTab.tsx
+++ b/src/components/Chat/ChatTab.tsx
@@ -12,6 +12,7 @@ import {
   Select,
   Spinner,
   Center,
+  useToast,
 } from '@chakra-ui/react'
 import { ArrowUpIcon } from '@chakra-ui/icons'
 import { supabase } from '../../lib/supabase'
@@ -34,6 +35,7 @@ function formatStamp(iso: string | null) {
 
 export default function ChatTab() {
   const { user, teams } = useAuth()
+  const toast = useToast()
   const [teamId, setTeamId] = useState<string | null>(teams[0]?.id ?? null)
   const [messages, setMessages] = useState<MessageRow[]>([])
   const [memberNames, setMemberNames] = useState<Map<string, string>>(new Map())
@@ -128,6 +130,7 @@ export default function ChatTab() {
         .insert({ teamId, userId: user.id, body })
       if (error) {
         console.error('send message error', error)
+        toast({ status: 'error', title: '送信できませんでした', description: error.message })
         return
       }
       setDraft('')

--- a/supabase/migrations/0010_rate_limiting.sql
+++ b/supabase/migrations/0010_rate_limiting.sql
@@ -1,0 +1,81 @@
+-- ============================================================
+-- 0010_rate_limiting.sql
+-- 濫用対策: フレンド申請・チームメッセージのレート制限（DB トリガー）
+--
+-- BEFORE INSERT トリガーで、直近の一定時間に同一ユーザーが作成した行数を数え、
+-- 上限を超える場合は例外を投げて挿入を拒否する。
+-- 正確にカウントするため SECURITY DEFINER（RLS の影響を受けない）+ search_path 固定。
+-- ============================================================
+
+-- ---------- チームメッセージ: 10秒で10件まで ----------
+CREATE OR REPLACE FUNCTION enforce_team_message_rate_limit()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_catalog
+AS $$
+DECLARE
+  recent integer;
+BEGIN
+  SELECT count(*) INTO recent
+  FROM team_messages
+  WHERE "userId" = NEW."userId"
+    AND "createdAt" > now() - interval '10 seconds';
+
+  IF recent >= 10 THEN
+    RAISE EXCEPTION 'メッセージの送信が多すぎます。少し時間をおいてからお試しください。'
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_team_message_rate_limit ON team_messages;
+CREATE TRIGGER trg_team_message_rate_limit
+  BEFORE INSERT ON team_messages
+  FOR EACH ROW EXECUTE FUNCTION enforce_team_message_rate_limit();
+
+-- ---------- フレンド申請: 1分で10件 / 1時間で30件まで ----------
+CREATE OR REPLACE FUNCTION enforce_friend_request_rate_limit()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_catalog
+AS $$
+DECLARE
+  per_minute integer;
+  per_hour integer;
+BEGIN
+  SELECT count(*) INTO per_minute
+  FROM friend_requests
+  WHERE "requesterId" = NEW."requesterId"
+    AND "createdAt" > now() - interval '1 minute';
+
+  IF per_minute >= 10 THEN
+    RAISE EXCEPTION 'フレンド申請が多すぎます。少し時間をおいてからお試しください。'
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  SELECT count(*) INTO per_hour
+  FROM friend_requests
+  WHERE "requesterId" = NEW."requesterId"
+    AND "createdAt" > now() - interval '1 hour';
+
+  IF per_hour >= 30 THEN
+    RAISE EXCEPTION '1時間あたりのフレンド申請の上限に達しました。時間をおいてからお試しください。'
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_friend_request_rate_limit ON friend_requests;
+CREATE TRIGGER trg_friend_request_rate_limit
+  BEFORE INSERT ON friend_requests
+  FOR EACH ROW EXECUTE FUNCTION enforce_friend_request_rate_limit();
+
+-- トリガー関数は直接呼び出させない
+REVOKE ALL ON FUNCTION enforce_team_message_rate_limit() FROM public;
+REVOKE ALL ON FUNCTION enforce_friend_request_rate_limit() FROM public;


### PR DESCRIPTION
## 概要
issue #55（レート制限/濫用対策）に対応。フレンド申請スパム・チームメッセージ濫用を DB トリガーで防止します。

## 変更内容（migration 0010）
- **チームメッセージ**: 同一ユーザー 10 秒で 10 件まで
- **フレンド申請**: 同一ユーザー 1 分で 10 件 / 1 時間で 30 件まで
- 上限超過時は `BEFORE INSERT` トリガーが例外を投げて挿入を拒否
- 正確にカウントするため SECURITY DEFINER + `search_path` 固定（0008 の方針に準拠）、トリガー関数は public から REVOKE
- ChatTab: 送信失敗時にエラーを toast 表示（FriendsTab は既に対応済み）

## 完了条件（issueより）
- [x] 一定時間あたりの申請/投稿数に上限 → トリガーで実装

## レビュアーへの補足
- **migration 0010 はリモート DB に適用済み**（dry-run で対象確認 → 0010 のみ push）。
- 上限値は安全側の初期値。運用を見て調整可能。
- 「ブロック機能」は issue 内で「検討」とされており本 PR では未対応（別 issue 化を推奨）。

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)