### PR TITLE
perf: タブのコード分割で初期バンドルを削減（#53）

### DIFF
--- a/src/components/Layout/MainLayout.tsx
+++ b/src/components/Layout/MainLayout.tsx
@@ -1,9 +1,4 @@
-import { useState } from 'react'
-import CalendarTab from '../Calendar/CalendarTab'
-import MapTab from '../Map/MapTab'
-import TeamsTab from '../Team/TeamsTab'
-import ChatTab from '../Chat/ChatTab'
-import FriendsTab from '../Friends/FriendsTab'
+import { lazy, Suspense, useState } from 'react'
 import {
   Box,
   Flex,
@@ -22,14 +17,30 @@ import {
   Avatar,
   HStack,
   Container,
+  Center,
+  Spinner,
   useDisclosure,
 } from '@chakra-ui/react'
 import { useAuth } from '../../hooks/useAuth'
 import { Wordmark } from '../ui/Wordmark'
 import { AccountModal } from '../Account/AccountModal'
 
-// CalendarTab is implemented in src/components/Calendar/CalendarTab.tsx
-// MapTab (live Leaflet map) is implemented in src/components/Map/MapTab.tsx
+// Each tab is code-split: its JS (incl. Leaflet for the map) only loads when the
+// tab is first opened, keeping the initial bundle small. `isLazy` on <Tabs>
+// ensures panels mount on demand, which triggers these dynamic imports.
+const CalendarTab = lazy(() => import('../Calendar/CalendarTab'))
+const MapTab = lazy(() => import('../Map/MapTab'))
+const ChatTab = lazy(() => import('../Chat/ChatTab'))
+const FriendsTab = lazy(() => import('../Friends/FriendsTab'))
+const TeamsTab = lazy(() => import('../Team/TeamsTab'))
+
+function TabFallback() {
+  return (
+    <Center py={20}>
+      <Spinner color="primary.500" thickness="3px" />
+    </Center>
+  )
+}
 
 export function MainLayout() {
   const { user, profile, signOut } = useAuth()
@@ -142,19 +153,29 @@ export function MainLayout() {
         <Container as="main" maxW="6xl" px={{ base: 4, md: 6 }} py={{ base: 5, md: 8 }}>
           <TabPanels>
             <TabPanel p={0}>
-              <CalendarTab />
+              <Suspense fallback={<TabFallback />}>
+                <CalendarTab />
+              </Suspense>
             </TabPanel>
             <TabPanel p={0}>
-              <MapTab />
+              <Suspense fallback={<TabFallback />}>
+                <MapTab />
+              </Suspense>
             </TabPanel>
             <TabPanel p={0}>
-              <ChatTab />
+              <Suspense fallback={<TabFallback />}>
+                <ChatTab />
+              </Suspense>
             </TabPanel>
             <TabPanel p={0}>
-              <FriendsTab />
+              <Suspense fallback={<TabFallback />}>
+                <FriendsTab />
+              </Suspense>
             </TabPanel>
             <TabPanel p={0}>
-              <TeamsTab />
+              <Suspense fallback={<TabFallback />}>
+                <TeamsTab />
+              </Suspense>
             </TabPanel>
           </TabPanels>
         </Container>

--- a/src/components/Map/MapTab.tsx
+++ b/src/components/Map/MapTab.tsx
@@ -1,3 +1,4 @@
+import 'leaflet/dist/leaflet.css'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { MapContainer, TileLayer, Marker, Popup, useMap, useMapEvents } from 'react-leaflet'
 import {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,4 +1,3 @@
-import 'leaflet/dist/leaflet.css'
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'


### PR DESCRIPTION
## 概要
issue #53。タブを動的 import でコード分割し、初期バンドル（特にモバイル）を軽量化します。

## 変更内容
- `MainLayout` の5タブ（カレンダー/マップ/チャット/フレンド/チーム）を `React.lazy` + `Suspense` 化。`<Tabs isLazy>` と併用し、**タブを開いた時にだけ**該当チャンクを読み込む。
- Leaflet CSS を `main.tsx` から `MapTab` へ移動し、地図チャンクに同梱。

## 効果（本番ビルド）
分割後の主なチャンク:
- `MapTab`（Leaflet 含む）≈ 160KB / gzip 48KB → **地図タブを開くまで読み込まれない**
- `CalendarTab` ≈ 33KB、`ChatTab`/`FriendsTab`/`TeamsTab` も個別遅延
- 初期JS: 従来の単一バンドル ~929KB → entry + auth(supabase) ~770KB に縮小し、地図・各タブは遅延化

## 完了条件
- [x] 初期バンドルの明確な削減（Leaflet ~160KB + 各タブを初期ロードから除外）

## 補足
- 残る大きめチャンクは Chakra UI(entry) と supabase-js(auth) で、いずれも起動時に必要なため本 PR の対象外。
- 検証: 本番ビルド成功＋全タブが default export であることを確認（lazy 解決成立）。

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)