### PR TITLE
feat: モバイルでカレンダーのサイドバー機能を利用可能に（#48）

### DIFF
--- a/src/components/Calendar/CalendarSidebar.tsx
+++ b/src/components/Calendar/CalendarSidebar.tsx
@@ -44,7 +44,24 @@ interface CalendarSidebarProps {
   onToggleTeam: (teamId: string) => void
 }
 
-export function CalendarSidebar({
+// Desktop wrapper: the sidebar fixed to the left, hidden below `lg`.
+export function CalendarSidebar(props: CalendarSidebarProps) {
+  return (
+    <Box
+      w="260px"
+      flexShrink={0}
+      display={{ base: 'none', lg: 'block' }}
+      pr={6}
+      maxH={{ lg: 'calc(100dvh - 136px)' }}
+      overflowY={{ lg: 'auto' }}
+    >
+      <CalendarSidebarBody {...props} />
+    </Box>
+  )
+}
+
+// The sidebar's contents. Shared by the desktop sidebar and the mobile drawer.
+export function CalendarSidebarBody({
   anchor,
   now,
   onPickDate,
@@ -72,14 +89,7 @@ export function CalendarSidebar({
   }, [miniMonth])
 
   return (
-    <Box
-      w="260px"
-      flexShrink={0}
-      display={{ base: 'none', lg: 'block' }}
-      pr={6}
-      maxH={{ lg: 'calc(100dvh - 136px)' }}
-      overflowY={{ lg: 'auto' }}
-    >
+    <Box>
       <Button
         variant="signal"
         leftIcon={<AddIcon boxSize={3} />}

--- a/src/components/Calendar/CalendarTab.tsx
+++ b/src/components/Calendar/CalendarTab.tsx
@@ -9,19 +9,25 @@ import {
   MenuButton,
   MenuList,
   MenuItem,
+  Drawer,
+  DrawerOverlay,
+  DrawerContent,
+  DrawerBody,
+  DrawerHeader,
+  DrawerCloseButton,
   useDisclosure,
   useToast,
   Spinner,
   Center,
 } from '@chakra-ui/react'
-import { ChevronLeftIcon, ChevronRightIcon, ChevronDownIcon, RepeatIcon } from '@chakra-ui/icons'
+import { ChevronLeftIcon, ChevronRightIcon, ChevronDownIcon, RepeatIcon, HamburgerIcon, AddIcon } from '@chakra-ui/icons'
 import { supabase } from '../../lib/supabase'
 import { useAuth } from '../../hooks/useAuth'
 import { Button } from '../ui/Button'
 import { EventModal } from './EventModal'
 import { TimeGridView } from './TimeGridView'
 import { MonthView } from './MonthView'
-import { CalendarSidebar } from './CalendarSidebar'
+import { CalendarSidebar, CalendarSidebarBody } from './CalendarSidebar'
 import {
   EMPTY_FORM,
   eventToForm,
@@ -55,6 +61,8 @@ export default function CalendarTab() {
   const [hiddenTeams, setHiddenTeams] = useState<Set<string>>(() => new Set())
 
   const { isOpen, onOpen, onClose } = useDisclosure()
+  // Mobile drawer that hosts the sidebar (create / mini-calendar / filters).
+  const mobileNav = useDisclosure()
   const toast = useToast()
   const [form, setForm] = useState<EventForm>(EMPTY_FORM)
   // id of the event being edited; null when creating a new one
@@ -313,6 +321,13 @@ export default function CalendarTab() {
           mb={5}
         >
           <HStack spacing={3}>
+            <IconButton
+              aria-label="メニュー"
+              icon={<HamburgerIcon boxSize={5} />}
+              variant="secondary"
+              display={{ base: 'inline-flex', lg: 'none' }}
+              onClick={mobileNav.onOpen}
+            />
             <HStack
               spacing={0}
               bg="paper-2"
@@ -396,6 +411,53 @@ export default function CalendarTab() {
         setForm={setForm}
         onSubmit={handleSubmit}
         isEditing={!!editingId}
+      />
+
+      {/* Mobile: sidebar contents in a drawer */}
+      <Drawer isOpen={mobileNav.isOpen} placement="left" onClose={mobileNav.onClose} size="xs">
+        <DrawerOverlay />
+        <DrawerContent>
+          <DrawerCloseButton />
+          <DrawerHeader fontFamily="heading">カレンダー</DrawerHeader>
+          <DrawerBody pb={6}>
+            <CalendarSidebarBody
+              anchor={anchor}
+              now={now}
+              onPickDate={(d) => {
+                setAnchor(startOfDay(d))
+                mobileNav.onClose()
+              }}
+              onCreate={() => {
+                mobileNav.onClose()
+                openBlank()
+              }}
+              filters={filters}
+              onToggleFilter={toggleFilter}
+              teams={teams}
+              hiddenTeams={hiddenTeams}
+              onToggleTeam={toggleTeam}
+            />
+          </DrawerBody>
+        </DrawerContent>
+      </Drawer>
+
+      {/* Mobile: floating "create" button */}
+      <IconButton
+        aria-label="予定を作成"
+        icon={<AddIcon />}
+        onClick={openBlank}
+        display={{ base: 'inline-flex', lg: 'none' }}
+        position="fixed"
+        bottom={6}
+        right={6}
+        zIndex={20}
+        boxSize={14}
+        borderRadius="full"
+        bg="signal.500"
+        color="white"
+        boxShadow="lg"
+        _hover={{ bg: 'signal.600' }}
+        _active={{ bg: 'signal.700' }}
       />
     </Flex>
   )


### PR DESCRIPTION
## 概要
issue #48。これまで `lg` 以上でしか表示されなかったカレンダーのサイドバー一式（作成・ミニカレンダー・今日・公開範囲/チームフィルタ）を、モバイルでも使えるようにしました。

## 変更内容
- `CalendarSidebar` の内容を **`CalendarSidebarBody`** として切り出し、デスクトップの固定サイドバーとモバイルのドロワーで共用（重複なし）
- ツールバーに**ハンバーガーボタン（`lg` 未満のみ）**を追加 → 左からドロワーでサイドバーを開く
- モバイル用の**「作成」FAB**（右下固定）を追加
- ドロワー内で日付選択・作成すると自動で閉じる

## 完了条件
- [x] スマホ幅で予定作成・チーム/公開範囲フィルタ・日付移動が可能

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)