### PR TITLE
feat: 予定の繰り返し（毎日/毎週/毎月）対応（#51 一部）

### DIFF
--- a/src/components/Calendar/CalendarTab.tsx
+++ b/src/components/Calendar/CalendarTab.tsx
@@ -25,6 +25,7 @@ import { CalendarSidebar } from './CalendarSidebar'
 import {
   EMPTY_FORM,
   eventToForm,
+  eventsForRange,
   startOfWeek,
   startOfDay,
   addDays,
@@ -91,19 +92,35 @@ export default function CalendarTab() {
     if (opts?.silent) setRefreshing(true)
     else setLoading(true)
     try {
-      const { data, error } = await supabase
-        .from('events')
-        .select('*')
-        .in('teamId', teamIds)
-        .lt('startAt', rangeEnd.toISOString())
-        .gt('endAt', rangeStart.toISOString())
-        .order('startAt', { ascending: true })
+      // (1) Non-recurring events (and recurring masters) overlapping the range.
+      // (2) Recurring masters that started before the range but recur into it.
+      // Merge + de-dupe; occurrences are expanded client-side via eventsForRange.
+      const [inRange, recurringMasters] = await Promise.all([
+        supabase
+          .from('events')
+          .select('*')
+          .in('teamId', teamIds)
+          .lt('startAt', rangeEnd.toISOString())
+          .gt('endAt', rangeStart.toISOString())
+          .order('startAt', { ascending: true }),
+        supabase
+          .from('events')
+          .select('*')
+          .in('teamId', teamIds)
+          .neq('recurrence', 'none')
+          .lt('startAt', rangeEnd.toISOString()),
+      ])
+      const error = inRange.error || recurringMasters.error
       if (error) {
         console.error('fetch events error', error)
         if (opts?.silent) toast({ status: 'error', title: '更新できませんでした', description: error.message })
         setEvents([])
       } else {
-        setEvents((data as EventRow[]) || [])
+        const byId = new Map<string, EventRow>()
+        for (const e of [...(inRange.data ?? []), ...(recurringMasters.data ?? [])] as EventRow[]) {
+          byId.set(e.id, e)
+        }
+        setEvents(Array.from(byId.values()))
       }
     } finally {
       if (opts?.silent) setRefreshing(false)
@@ -117,10 +134,10 @@ export default function CalendarTab() {
 
   const visibleEvents = useMemo(
     () =>
-      events.filter(
+      eventsForRange(events, rangeStart, rangeEnd).filter(
         (e) => filters.has(e.sharingState as SharingState) && !hiddenTeams.has(e.teamId),
       ),
-    [events, filters, hiddenTeams],
+    [events, filters, hiddenTeams, rangeStart, rangeEnd],
   )
 
   const days = useMemo(() => {
@@ -257,6 +274,8 @@ export default function CalendarTab() {
       isAllDay: form.isAllDay,
       eventLocation: form.eventLocation || null,
       sharingState: form.sharingState as SharingState,
+      recurrence: form.recurrence,
+      recurrenceEndDate: form.recurrence !== 'none' && form.recurrenceEndDate ? form.recurrenceEndDate : null,
     }
 
     const { error } = editingId

--- a/src/components/Calendar/EventModal.tsx
+++ b/src/components/Calendar/EventModal.tsx
@@ -18,7 +18,7 @@ import {
 } from '@chakra-ui/react'
 import { Button } from '../ui/Button'
 import { Input } from '../ui/Input'
-import { SHARING, TIME_OPTIONS, type EventForm, type SharingState } from './calendarUtils'
+import { SHARING, RECURRENCE_LABEL, TIME_OPTIONS, type EventForm, type SharingState } from './calendarUtils'
 
 interface EventModalProps {
   isOpen: boolean
@@ -139,6 +139,32 @@ export function EventModal({ isOpen, onClose, form, setForm, onSubmit, isEditing
                 <option value="team">チーム</option>
               </Select>
             </FormControl>
+
+            <FormControl>
+              <FormLabel>繰り返し</FormLabel>
+              <Select
+                value={form.recurrence}
+                onChange={(e) => setForm({ ...form, recurrence: e.target.value as EventForm['recurrence'] })}
+              >
+                {(Object.keys(RECURRENCE_LABEL) as EventForm['recurrence'][]).map((r) => (
+                  <option key={r} value={r}>
+                    {RECURRENCE_LABEL[r]}
+                  </option>
+                ))}
+              </Select>
+            </FormControl>
+
+            {form.recurrence !== 'none' && (
+              <FormControl>
+                <FormLabel>繰り返しの終了日（任意）</FormLabel>
+                <ChakraInput
+                  type="date"
+                  value={form.recurrenceEndDate}
+                  min={form.startDate || undefined}
+                  onChange={(e) => setForm({ ...form, recurrenceEndDate: e.target.value })}
+                />
+              </FormControl>
+            )}
           </VStack>
         </ModalBody>
 

--- a/src/components/Calendar/calendarUtils.ts
+++ b/src/components/Calendar/calendarUtils.ts
@@ -2,7 +2,15 @@ import type { Database } from '../../types/database'
 
 export type EventRow = Database['public']['Tables']['events']['Row']
 export type SharingState = EventRow['sharingState']
+export type Recurrence = EventRow['recurrence']
 export type CalendarView = 'day' | 'week' | 'month'
+
+export const RECURRENCE_LABEL: Record<Recurrence, string> = {
+  none: '繰り返さない',
+  daily: '毎日',
+  weekly: '毎週',
+  monthly: '毎月',
+}
 
 export const WEEKDAYS = ['日', '月', '火', '水', '木', '金', '土']
 
@@ -117,6 +125,8 @@ export interface EventForm {
   endTime: string
   eventLocation: string
   sharingState: string
+  recurrence: Recurrence
+  recurrenceEndDate: string
 }
 
 export const EMPTY_FORM: EventForm = {
@@ -128,6 +138,8 @@ export const EMPTY_FORM: EventForm = {
   endTime: '',
   eventLocation: '',
   sharingState: 'private',
+  recurrence: 'none',
+  recurrenceEndDate: '',
 }
 
 // Local "HH:MM" (avoids the UTC shift of toISOString / getUTCHours).
@@ -151,7 +163,57 @@ export function eventToForm(ev: EventRow): EventForm {
     endTime: ev.isAllDay ? '' : toTimeInput(end),
     eventLocation: ev.eventLocation ?? '',
     sharingState: ev.sharingState,
+    recurrence: ev.recurrence ?? 'none',
+    recurrenceEndDate: ev.recurrenceEndDate ?? '',
   }
+}
+
+// Expand a recurring "master" event into concrete occurrences that overlap the
+// [rangeStart, rangeEnd) window. Each occurrence keeps the master's id (so
+// clicking it edits the master) but carries shifted start/end times.
+// Non-recurring events should be passed through directly, not via this helper.
+export function expandRecurring(master: EventRow, rangeStart: Date, rangeEnd: Date): EventRow[] {
+  if (!master.recurrence || master.recurrence === 'none') return []
+
+  const start = new Date(master.startAt)
+  const durationMs = new Date(master.endAt).getTime() - start.getTime()
+  // Inclusive end-of-day of the recurrence end date (or no bound).
+  const until = master.recurrenceEndDate
+    ? addDays(startOfDay(new Date(`${master.recurrenceEndDate}T00:00`)), 1)
+    : null
+
+  const step = (d: Date): Date => {
+    if (master.recurrence === 'daily') return addDays(d, 1)
+    if (master.recurrence === 'weekly') return addDays(d, 7)
+    return addMonths(d, 1) // monthly
+  }
+
+  const occurrences: EventRow[] = []
+  let cursor = new Date(start)
+  // Safety cap to avoid runaway loops on bad data.
+  for (let i = 0; i < 400 && cursor < rangeEnd; i++) {
+    if (until && cursor >= until) break
+    const occEnd = new Date(cursor.getTime() + durationMs)
+    if (occEnd > rangeStart) {
+      occurrences.push({ ...master, startAt: cursor.toISOString(), endAt: occEnd.toISOString() })
+    }
+    cursor = step(cursor)
+  }
+  return occurrences
+}
+
+// Build the list of events to render for a range: non-recurring events as-is,
+// plus expanded occurrences of recurring masters.
+export function eventsForRange(events: EventRow[], rangeStart: Date, rangeEnd: Date): EventRow[] {
+  const result: EventRow[] = []
+  for (const ev of events) {
+    if (!ev.recurrence || ev.recurrence === 'none') {
+      result.push(ev)
+    } else {
+      result.push(...expandRecurring(ev, rangeStart, rangeEnd))
+    }
+  }
+  return result
 }
 
 export type Positioned = {

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -164,6 +164,8 @@ export type Database = {
           isAllDay: boolean
           eventLocation: string | null
           sharingState: 'private' | 'friends' | 'team'
+          recurrence: 'none' | 'daily' | 'weekly' | 'monthly'
+          recurrenceEndDate: string | null
           createdAt: string | null
         }
         Insert: {
@@ -176,6 +178,8 @@ export type Database = {
           isAllDay?: boolean
           eventLocation?: string | null
           sharingState?: 'private' | 'friends' | 'team'
+          recurrence?: 'none' | 'daily' | 'weekly' | 'monthly'
+          recurrenceEndDate?: string | null
           createdAt?: string | null
         }
         Update: {
@@ -188,6 +192,8 @@ export type Database = {
           isAllDay?: boolean
           eventLocation?: string | null
           sharingState?: 'private' | 'friends' | 'team'
+          recurrence?: 'none' | 'daily' | 'weekly' | 'monthly'
+          recurrenceEndDate?: string | null
           createdAt?: string | null
         }
         Relationships: []

--- a/supabase/migrations/0011_event_recurrence.sql
+++ b/supabase/migrations/0011_event_recurrence.sql
@@ -1,0 +1,15 @@
+-- ============================================================
+-- 0011_event_recurrence.sql
+-- 予定の繰り返し（なし/毎日/毎週/毎月）対応
+--
+-- マスター予定 1 行に繰り返しルールを持たせ、表示時にクライアント側で
+-- 期間内のオカレンスへ展開する（シンプルな RRULE 相当）。
+-- ============================================================
+
+ALTER TABLE events
+  ADD COLUMN IF NOT EXISTS recurrence text NOT NULL DEFAULT 'none'
+    CHECK (recurrence IN ('none', 'daily', 'weekly', 'monthly'));
+
+-- 繰り返しの終了日（その日まで。NULL は無期限）
+ALTER TABLE events
+  ADD COLUMN IF NOT EXISTS "recurrenceEndDate" date;


### PR DESCRIPTION
## 概要
issue #51 のうち、コードのみで完結する **繰り返し予定** を実装しました。

## 変更内容
- **migration 0011**: `events` に `recurrence`（none/daily/weekly/monthly）と `recurrenceEndDate`（任意）を追加
- **EventModal**: 「繰り返し」種別と「繰り返しの終了日（任意）」の入力を追加
- **calendarUtils**: `expandRecurring()` / `eventsForRange()` を追加し、繰り返しマスター1行を表示範囲内のオカレンスへ展開（暴走防止に上限あり）
- **CalendarTab**: 範囲外で始まり範囲内に繰り返すマスターも取得し、表示時に展開。オカレンスはマスター id を保持するため、クリックすると**マスターを編集**

## スコープと既知の制限（#51 の残り）
- **リマインダー**: 通知基盤（#50, 未実装）に依存するため本 PR では対象外。
- **タイムゾーン**: 予定は現状 UTC 瞬時で保存しローカル表示。完全な複数 TZ 対応は規模が大きいため別 PR を推奨。
- 繰り返しの**個別回の例外編集/削除**は未対応（編集・削除はマスター単位）。月末日（例: 31日）の毎月繰り返しは JS の月送り挙動に従う。

→ 上記2点（リマインダー / タイムゾーン）は #51 に残すか、サブ issue 化を推奨します。

## 確認
- [x] `npm run build` 成功
- [x] migration 0011 をリモート適用済み

Refs #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)