### PR TITLE
招待コードでのチーム参加機能を追加

### DIFF
--- a/src/components/Auth/TeamSetup.tsx
+++ b/src/components/Auth/TeamSetup.tsx
@@ -1,5 +1,15 @@
 import { useState } from 'react'
-import { Button, Input, VStack, Text } from '@chakra-ui/react'
+import {
+  Button,
+  Input,
+  VStack,
+  Text,
+  Tabs,
+  TabList,
+  TabPanels,
+  Tab,
+  TabPanel,
+} from '@chakra-ui/react'
 import { supabase } from '../../lib/supabase'
 import { useAuth } from '../../hooks/useAuth'
 import type { Database } from '../../types/database'
@@ -10,6 +20,7 @@ type UserTeamInsert = Database['public']['Tables']['user_teams']['Insert']
 export function TeamSetup() {
   const { user, refreshProfile } = useAuth()
   const [teamName, setTeamName] = useState('')
+  const [invitationalCode, setInvitationalCode] = useState('')
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -19,12 +30,13 @@ export function TeamSetup() {
       setError('チーム名を入力してください')
       return
     }
+    setError(null)
     setLoading(true)
     try {
-      const invitationalCode = Math.random().toString(36).slice(2, 8)
+      const code = Math.random().toString(36).slice(2, 8)
       const { data: teamData, error: teamError } = await supabase
         .from('teams')
-        .insert([{ teamName: teamName.trim(), invitationalCode } as TeamInsert])
+        .insert([{ teamName: teamName.trim(), invitationalCode: code } as TeamInsert])
         .select()
         .single()
 
@@ -46,11 +58,33 @@ export function TeamSetup() {
 
       await refreshProfile()
     } catch (e: unknown) {
-      if (e instanceof Error) {
-        setError(e.message)
-      } else {
-        setError(String(e))
+      setError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleJoin = async () => {
+    if (!invitationalCode || invitationalCode.trim() === '') {
+      setError('招待コードを入力してください')
+      return
+    }
+    setError(null)
+    setLoading(true)
+    try {
+      const { error: rpcError } = await supabase.rpc('join_team_by_code', {
+        code: invitationalCode.trim(),
+      })
+
+      if (rpcError) {
+        setError(rpcError.message)
+        setLoading(false)
+        return
       }
+
+      await refreshProfile()
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : String(e))
     } finally {
       setLoading(false)
     }
@@ -59,11 +93,41 @@ export function TeamSetup() {
   return (
     <VStack spacing={4} p={6} maxW="480px" margin="0 auto">
       <Text fontSize="lg">チームを作成するか参加してください</Text>
-      <Input value={teamName} onChange={(e) => setTeamName(e.target.value)} placeholder="チーム名" />
+
+      <Tabs w="full" isFitted onChange={() => setError(null)}>
+        <TabList>
+          <Tab>チームを作成する</Tab>
+          <Tab>招待コードで参加</Tab>
+        </TabList>
+        <TabPanels>
+          <TabPanel>
+            <VStack spacing={4}>
+              <Input
+                value={teamName}
+                onChange={(e) => setTeamName(e.target.value)}
+                placeholder="チーム名"
+              />
+              <Button onClick={handleCreate} isLoading={loading} colorScheme="green" w="full">
+                チーム作成
+              </Button>
+            </VStack>
+          </TabPanel>
+          <TabPanel>
+            <VStack spacing={4}>
+              <Input
+                value={invitationalCode}
+                onChange={(e) => setInvitationalCode(e.target.value)}
+                placeholder="招待コード"
+              />
+              <Button onClick={handleJoin} isLoading={loading} colorScheme="green" w="full">
+                参加する
+              </Button>
+            </VStack>
+          </TabPanel>
+        </TabPanels>
+      </Tabs>
+
       {error && <Text color="red.500">{error}</Text>}
-      <Button onClick={handleCreate} isLoading={loading} colorScheme="green">
-        チーム作成
-      </Button>
     </VStack>
   )
 }

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -167,7 +167,12 @@ export type Database = {
       }
     }
     Views: { [_ in never]: never }
-    Functions: { [_ in never]: never }
+    Functions: {
+      join_team_by_code: {
+        Args: { code: string }
+        Returns: string
+      }
+    }
     Enums: {
       sharing_state: 'private' | 'friends' | 'team'
     }

--- a/supabase/migrations/0002_join_team_by_code.sql
+++ b/supabase/migrations/0002_join_team_by_code.sql
@@ -1,0 +1,40 @@
+-- ============================================================
+-- 0002_join_team_by_code.sql
+-- 招待コードでチームに参加する RPC
+--
+-- teams_select policy はユーザーが既に所属するチームしか
+-- SELECT を許可しないため、参加前のチームをクライアントから
+-- 直接 invitationalCode で検索することはできない。
+-- SECURITY DEFINER 関数で検索と user_teams への INSERT を
+-- まとめて行うことで、teams テーブルの参照範囲を広げずに
+-- 招待コード参加を実現する。
+-- ============================================================
+
+DROP FUNCTION IF EXISTS public.join_team_by_code(text);
+
+CREATE OR REPLACE FUNCTION public.join_team_by_code(code text)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_team_id uuid;
+BEGIN
+  SELECT id INTO v_team_id
+  FROM teams
+  WHERE "invitationalCode" = code;
+
+  IF v_team_id IS NULL THEN
+    RAISE EXCEPTION '招待コードが見つかりません';
+  END IF;
+
+  INSERT INTO user_teams ("userId", "teamId", role)
+  VALUES (auth.uid(), v_team_id, 'member')
+  ON CONFLICT ("userId", "teamId") DO NOTHING;
+
+  RETURN v_team_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.join_team_by_code(text) TO authenticated;


### PR DESCRIPTION
## Summary
- `TeamSetup` にタブUI（「チームを作成する」/「招待コードで参加」）を追加し、招待コードでの参加フローを実装（Issue #5）
- `teams_select` の RLS は未所属チームの SELECT を許可しないため、`SECURITY DEFINER` の `join_team_by_code(code)` RPC（`supabase/migrations/0002_join_team_by_code.sql`）を新設し、検索と `user_teams` への INSERT をサーバー側でまとめて実行
- `src/types/database.ts` に `join_team_by_code` の `Functions` 型を追加
- Issue #6（AuthGuardへのチーム所属チェック追加）は PR #16 で対応済みのためクローズ

## Test plan
- [x] `npm run lint`
- [x] `npm run build`
- [ ] `npx supabase db push`（または SQL Editor で `0002_join_team_by_code.sql` を適用）— **マージ後に手動で実施が必要**
- [ ] 実際のSupabase環境で招待コード参加の動作確認

https://claude.ai/code/session_01BbVTK67kCbXBaifjZ3r9Q2


---
_Generated by [Claude Code](https://claude.ai/code/session_01BbVTK67kCbXBaifjZ3r9Q2)_