### PR TITLE
feat: カレンダーに日本の祝日を表示（#34）

### DIFF
--- a/src/components/Calendar/MonthView.tsx
+++ b/src/components/Calendar/MonthView.tsx
@@ -10,6 +10,7 @@ import {
   type EventRow,
   type SharingState,
 } from './calendarUtils'
+import { getHolidayName } from './holidays'
 
 interface MonthViewProps {
   anchor: Date
@@ -47,6 +48,9 @@ export function MonthView({ anchor, events, now, onDayClick, onEventClick }: Mon
           const inMonth = isSameMonth(d, anchor)
           const today = isSameDay(d, now)
           const dow = d.getDay()
+          const holiday = getHolidayName(d)
+          // 祝日は日曜と同じく赤系で表示する。
+          const isRed = dow === 0 || holiday !== null
           const dayEvents = events
             .filter((e) => overlapsDay(e, d))
             .sort((a, b) => {
@@ -86,7 +90,7 @@ export function MonthView({ anchor, events, now, onDayClick, onEventClick }: Mon
                         ? 'white'
                         : !inMonth
                           ? 'gray.400'
-                          : dow === 0
+                          : isRed
                             ? 'danger.500'
                             : dow === 6
                               ? 'primary.600'
@@ -97,6 +101,20 @@ export function MonthView({ anchor, events, now, onDayClick, onEventClick }: Mon
                   </Text>
                 </Center>
               </Flex>
+
+              {holiday && (
+                <Text
+                  fontSize="10px"
+                  color="danger.500"
+                  fontWeight="600"
+                  textAlign="center"
+                  noOfLines={1}
+                  mt="-1"
+                  mb={1}
+                >
+                  {holiday}
+                </Text>
+              )}
 
               <VStack spacing="2px" align="stretch">
                 {shown.map((ev) => {

--- a/src/components/Calendar/TimeGridView.tsx
+++ b/src/components/Calendar/TimeGridView.tsx
@@ -16,6 +16,7 @@ import {
   type EventRow,
   type SharingState,
 } from './calendarUtils'
+import { getHolidayName } from './holidays'
 
 interface TimeGridViewProps {
   days: Date[]
@@ -75,6 +76,8 @@ export function TimeGridView({
             {days.map((d) => {
               const today = isSameDay(d, now)
               const dow = d.getDay()
+              const holiday = getHolidayName(d)
+              const isRed = dow === 0 || holiday !== null
               return (
                 <VStack
                   key={d.toISOString()}
@@ -88,7 +91,7 @@ export function TimeGridView({
                   <Text
                     fontSize="xs"
                     fontWeight="bold"
-                    color={dow === 0 ? 'danger.500' : dow === 6 ? 'primary.600' : 'gray.400'}
+                    color={isRed ? 'danger.500' : dow === 6 ? 'primary.600' : 'gray.400'}
                   >
                     {WEEKDAYS[dow]}
                   </Text>
@@ -98,11 +101,16 @@ export function TimeGridView({
                       fontWeight="700"
                       fontSize="lg"
                       lineHeight="1"
-                      color={today ? 'white' : 'gray.900'}
+                      color={today ? 'white' : isRed ? 'danger.500' : 'gray.900'}
                     >
                       {d.getDate()}
                     </Text>
                   </Center>
+                  {holiday && (
+                    <Text fontSize="10px" color="danger.500" fontWeight="600" noOfLines={1}>
+                      {holiday}
+                    </Text>
+                  )}
                 </VStack>
               )
             })}

--- a/src/components/Calendar/holidays.ts
+++ b/src/components/Calendar/holidays.ts
@@ -1,0 +1,93 @@
+// 日本の祝日（国民の祝日）を算出するユーティリティ。
+// 外部依存なし。現行の祝日法（2007年以降）に対応し、振替休日・国民の休日・
+// 春分/秋分の日（2000〜2099年の近似式）を含む。
+// 注: 2020/2021 の東京五輪に伴う特例移動には対応していない（通常年のルール）。
+
+import { toDateInput } from './calendarUtils'
+
+function nthMonday(year: number, month: number, n: number): number {
+  // month: 0-indexed。その月の第 n 月曜日の「日」を返す。
+  const first = new Date(year, month, 1).getDay() // 0=日
+  const firstMonday = ((8 - first) % 7) + 1
+  return firstMonday + (n - 1) * 7
+}
+
+// 春分の日（3月）/ 秋分の日（9月）の近似式（1980年基準, 2000-2099 有効）。
+function vernalEquinoxDay(year: number): number {
+  return Math.floor(20.8431 + 0.242194 * (year - 1980) - Math.floor((year - 1980) / 4))
+}
+function autumnalEquinoxDay(year: number): number {
+  return Math.floor(23.2488 + 0.242194 * (year - 1980) - Math.floor((year - 1980) / 4))
+}
+
+// その年の「固定的な」祝日（振替・国民の休日を適用する前）を算出。
+function fixedHolidays(year: number): Map<string, string> {
+  const m = new Map<string, string>()
+  const add = (month: number, day: number, name: string) => {
+    m.set(toDateInput(new Date(year, month - 1, day)), name)
+  }
+
+  add(1, 1, '元日')
+  add(1, nthMonday(year, 0, 2), '成人の日')
+  add(2, 11, '建国記念の日')
+  if (year >= 2020) add(2, 23, '天皇誕生日')
+  add(3, vernalEquinoxDay(year), '春分の日')
+  add(4, 29, '昭和の日')
+  add(5, 3, '憲法記念日')
+  add(5, 4, 'みどりの日')
+  add(5, 5, 'こどもの日')
+  add(7, nthMonday(year, 6, 3), '海の日')
+  if (year >= 2016) add(8, 11, '山の日')
+  add(9, nthMonday(year, 8, 3), '敬老の日')
+  add(9, autumnalEquinoxDay(year), '秋分の日')
+  add(10, nthMonday(year, 9, 2), year >= 2020 ? 'スポーツの日' : '体育の日')
+  add(11, 3, '文化の日')
+  add(11, 23, '勤労感謝の日')
+
+  return m
+}
+
+const cache = new Map<number, Map<string, string>>()
+
+function holidaysForYear(year: number): Map<string, string> {
+  const cached = cache.get(year)
+  if (cached) return cached
+
+  const base = fixedHolidays(year)
+  const result = new Map(base)
+
+  // 国民の休日: ある祝日の「翌日」が祝日でなく、その「翌々日」が祝日で、
+  // 挟まれた日が日曜でなければ休日になる。
+  // 例: 9月の敬老の日と秋分の日に挟まれた平日。
+  for (const key of base.keys()) {
+    const d = new Date(key)
+    const between = new Date(d)
+    between.setDate(d.getDate() + 1)
+    const after = new Date(d)
+    after.setDate(d.getDate() + 2)
+    const betweenKey = toDateInput(between)
+    if (base.has(toDateInput(after)) && !base.has(betweenKey) && between.getDay() !== 0) {
+      result.set(betweenKey, '国民の休日')
+    }
+  }
+
+  // 振替休日: 祝日が日曜なら、その後の最初の「祝日でない日」を休日にする。
+  for (const key of base.keys()) {
+    const d = new Date(key)
+    if (d.getDay() === 0) {
+      const sub = new Date(d)
+      do {
+        sub.setDate(sub.getDate() + 1)
+      } while (result.has(toDateInput(sub)))
+      result.set(toDateInput(sub), '振替休日')
+    }
+  }
+
+  cache.set(year, result)
+  return result
+}
+
+/** 指定日が祝日ならその名称、そうでなければ null を返す。 */
+export function getHolidayName(date: Date): string | null {
+  return holidaysForYear(date.getFullYear()).get(toDateInput(date)) ?? null
+}


### PR DESCRIPTION
## 概要
カレンダーに日本の祝日を表示する（#34 の残課題）。

## 変更点
- **`src/components/Calendar/holidays.ts`** を新規追加（外部依存なし）
  - 現行の祝日法（2007年以降）に対応
  - 春分の日 / 秋分の日（近似式, 2000-2099）
  - 振替休日（祝日が日曜の場合の次平日）
  - 国民の休日（祝日に挟まれた平日）
  - 結果は年単位でキャッシュ
- **月表示 / 週・日表示** で祝日を赤字＋名称ラベルで表示

## 動作確認
- `npm run build` / `tsc --noEmit` / `eslint` クリーン
- 2026年の全18祝日が公式の祝日と完全一致することを検証（振替休日 5/6・国民の休日 9/22 を含む）

## 補足
- 2020/2021 の五輪特例移動には未対応（通常年のルールで算出）

関連: #34（祝日対応）

🤖 Generated with [Claude Code](https://claude.com/claude-code)