### PR TITLE
chore(db): join_team_by_code のマイグレーションを追加（#68 を整理）

### DIFF
--- a/supabase/migrations/0007_join_team_by_code.sql
+++ b/supabase/migrations/0007_join_team_by_code.sql
@@ -1,0 +1,46 @@
+-- ============================================================
+-- 0007_join_team_by_code.sql
+-- 招待コードでチームに参加する RPC
+--
+-- teams_select policy はユーザーが既に所属するチームしか
+-- SELECT を許可しないため、参加前のチームをクライアントから
+-- 直接 invitationalCode で検索することはできない。
+-- SECURITY DEFINER 関数で検索と user_teams への INSERT を
+-- まとめて行うことで、teams テーブルの参照範囲を広げずに
+-- 招待コード参加を実現する。
+--
+-- 注: フロントエンド（TeamSetup / TeamsTab）は既にこの RPC を
+-- 呼び出しているが、関数定義のマイグレーションが欠けていた。
+-- 本ファイルでマイグレーション履歴に取り込み、新規環境でも
+-- 再現できるようにする。CREATE OR REPLACE のため再適用も安全。
+-- （元 PR #68 / Issue #5 から番号を 0002→0007 に修正して切り出し）
+-- ============================================================
+
+DROP FUNCTION IF EXISTS public.join_team_by_code(text);
+
+CREATE OR REPLACE FUNCTION public.join_team_by_code(code text)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_team_id uuid;
+BEGIN
+  SELECT id INTO v_team_id
+  FROM teams
+  WHERE "invitationalCode" = code;
+
+  IF v_team_id IS NULL THEN
+    RAISE EXCEPTION '招待コードが見つかりません';
+  END IF;
+
+  INSERT INTO user_teams ("userId", "teamId", role)
+  VALUES (auth.uid(), v_team_id, 'member')
+  ON CONFLICT ("userId", "teamId") DO NOTHING;
+
+  RETURN v_team_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.join_team_by_code(text) TO authenticated;


### PR DESCRIPTION
## 概要
招待コード参加に使う `join_team_by_code` RPC の**関数定義マイグレーションが欠落**していた問題を解消する。

フロントエンド（`TeamSetup` / `TeamsTab`）は既にこの RPC を呼び出しており、リモートDBには手動適用されているとみられるが、マイグレーション履歴に無いため新規環境で再現できなかった。

## 経緯（#68 の整理）
PR #68 はこの機能を実装していたが、
- フロント実装は既に main にマージ済み（重複）
- main とコンフリクト（DIRTY）
- マイグレーション番号 `0002` が既存 `0002_event_all_day.sql` と衝突

のためマージ不可だった。本PRは #68 の SQL のうち**関数定義のみ**を、番号を `0007` に修正して切り出したもの。`CREATE OR REPLACE` のため既存環境への再適用も安全。

## 変更
- `supabase/migrations/0007_join_team_by_code.sql` を追加

## 適用
- [ ] マージ後 `npx supabase db push`（または SQL Editor で適用）

関連: #5, #68（クローズ予定）

🤖 Generated with [Claude Code](https://claude.com/claude-code)