### PR TITLE
feat: 通知ベル＋未読バッジ（アプリ内通知の第一歩）（#50 一部）

### DIFF
--- a/src/components/Layout/MainLayout.tsx
+++ b/src/components/Layout/MainLayout.tsx
@@ -24,6 +24,7 @@ import {
 import { useAuth } from '../../hooks/useAuth'
 import { Wordmark } from '../ui/Wordmark'
 import { AccountModal } from '../Account/AccountModal'
+import { NotificationBell } from '../Notifications/NotificationBell'
 
 // Each tab is code-split: its JS (incl. Leaflet for the map) only loads when the
 // tab is first opened, keeping the initial bundle small. `isLazy` on <Tabs>
@@ -106,6 +107,8 @@ export function MainLayout() {
                 ))}
               </TabList>
 
+              <HStack spacing={1}>
+              <NotificationBell userId={user?.id} />
               <Menu>
                 <MenuButton
                   as={Button}
@@ -146,6 +149,7 @@ export function MainLayout() {
                   </MenuItem>
                 </MenuList>
               </Menu>
+              </HStack>
             </Flex>
           </Container>
         </Box>

--- a/src/components/Notifications/NotificationBell.tsx
+++ b/src/components/Notifications/NotificationBell.tsx
@@ -1,0 +1,137 @@
+import { useState } from 'react'
+import {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+  PopoverHeader,
+  PopoverBody,
+  Box,
+  Button,
+  IconButton,
+  HStack,
+  VStack,
+  Text,
+  Avatar,
+  Badge,
+  Center,
+  useToast,
+} from '@chakra-ui/react'
+import { supabase } from '../../lib/supabase'
+import { useNotifications } from '../../hooks/useNotifications'
+
+export function NotificationBell({ userId }: { userId: string | undefined }) {
+  const { friendRequests, unreadCount, refresh } = useNotifications(userId)
+  const toast = useToast()
+  const [busyId, setBusyId] = useState<string | null>(null)
+
+  async function accept(requestId: string, name: string) {
+    setBusyId(requestId)
+    try {
+      const { error } = await supabase.rpc('accept_friend_request', { request_id: requestId })
+      if (error) {
+        toast({ status: 'error', title: '承認できませんでした', description: error.message })
+        return
+      }
+      toast({ status: 'success', title: `${name} と友だちになりました` })
+      await refresh()
+    } finally {
+      setBusyId(null)
+    }
+  }
+
+  async function decline(requestId: string) {
+    setBusyId(requestId)
+    try {
+      await supabase.from('friend_requests').delete().eq('id', requestId)
+      await refresh()
+    } finally {
+      setBusyId(null)
+    }
+  }
+
+  return (
+    <Popover placement="bottom-end" isLazy>
+      <PopoverTrigger>
+        <Box position="relative" display="inline-flex">
+          <IconButton
+            aria-label="通知"
+            variant="ghost"
+            borderRadius="full"
+            fontSize="lg"
+            icon={<Box as="span">🔔</Box>}
+          />
+          {unreadCount > 0 && (
+            <Badge
+              position="absolute"
+              top={1}
+              right={1}
+              minW="18px"
+              h="18px"
+              px={1}
+              borderRadius="full"
+              bg="danger.500"
+              color="white"
+              fontSize="10px"
+              display="flex"
+              alignItems="center"
+              justifyContent="center"
+              pointerEvents="none"
+            >
+              {unreadCount > 9 ? '9+' : unreadCount}
+            </Badge>
+          )}
+        </Box>
+      </PopoverTrigger>
+      <PopoverContent borderRadius="xl" borderColor="gray.200" boxShadow="lg" w="320px" _focus={{ outline: 'none' }}>
+        <PopoverHeader fontWeight="semibold" borderColor="gray.100">
+          通知
+        </PopoverHeader>
+        <PopoverBody px={2} py={2} maxH="360px" overflowY="auto">
+          {friendRequests.length === 0 ? (
+            <Center py={8}>
+              <Text fontSize="sm" color="gray.500">
+                新しい通知はありません
+              </Text>
+            </Center>
+          ) : (
+            <VStack align="stretch" spacing={1}>
+              {friendRequests.map((n) => (
+                <Box key={n.requestId} px={2} py={2} borderRadius="md" _hover={{ bg: 'gray.50' }}>
+                  <HStack spacing={3} align="start">
+                    <Avatar size="sm" name={n.requester.displayName} bg="primary.500" color="white" />
+                    <Box minW={0} flex={1}>
+                      <Text fontSize="sm" color="gray.800">
+                        <Text as="span" fontWeight="600">
+                          {n.requester.displayName}
+                        </Text>{' '}
+                        さんからフレンド申請
+                      </Text>
+                      <HStack spacing={2} mt={2}>
+                        <Button
+                          size="xs"
+                          variant="signal"
+                          isLoading={busyId === n.requestId}
+                          onClick={() => accept(n.requestId, n.requester.displayName)}
+                        >
+                          承認
+                        </Button>
+                        <Button
+                          size="xs"
+                          variant="secondary"
+                          isDisabled={busyId === n.requestId}
+                          onClick={() => decline(n.requestId)}
+                        >
+                          拒否
+                        </Button>
+                      </HStack>
+                    </Box>
+                  </HStack>
+                </Box>
+              ))}
+            </VStack>
+          )}
+        </PopoverBody>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -1,0 +1,77 @@
+import { useCallback, useEffect, useState } from 'react'
+import { supabase } from '../lib/supabase'
+
+export interface FriendRequestNotification {
+  requestId: string
+  requester: { id: string; displayName: string; email: string }
+  createdAt: string | null
+}
+
+const POLL_MS = 30_000
+
+/**
+ * アプリ内通知。現状は「受け取ったフレンド申請」を扱う。
+ * 起動中は定期ポーリング＋タブ復帰時に再取得して未読件数を更新する。
+ * 将来 #50 で予定共有・位置共有などの通知も同じ仕組みに集約できる。
+ */
+export function useNotifications(userId: string | undefined) {
+  const [friendRequests, setFriendRequests] = useState<FriendRequestNotification[]>([])
+  const [loading, setLoading] = useState(false)
+
+  const refresh = useCallback(async () => {
+    if (!userId) {
+      setFriendRequests([])
+      return
+    }
+    setLoading(true)
+    try {
+      const { data: reqs } = await supabase
+        .from('friend_requests')
+        .select('id, requesterId, createdAt')
+        .eq('addresseeId', userId)
+        .eq('status', 'pending')
+        .order('createdAt', { ascending: false })
+
+      const rows = reqs ?? []
+      if (rows.length === 0) {
+        setFriendRequests([])
+        return
+      }
+      const ids = rows.map((r) => r.requesterId)
+      const { data: users } = await supabase
+        .from('users')
+        .select('id, displayName, email')
+        .in('id', ids)
+      const byId = new Map((users ?? []).map((u) => [u.id, u]))
+
+      setFriendRequests(
+        rows.map((r) => ({
+          requestId: r.id,
+          createdAt: r.createdAt,
+          requester: byId.get(r.requesterId) ?? {
+            id: r.requesterId,
+            displayName: '不明なユーザー',
+            email: '',
+          },
+        })),
+      )
+    } finally {
+      setLoading(false)
+    }
+  }, [userId])
+
+  useEffect(() => {
+    void refresh()
+    const id = setInterval(() => void refresh(), POLL_MS)
+    const onFocus = () => void refresh()
+    window.addEventListener('focus', onFocus)
+    return () => {
+      clearInterval(id)
+      window.removeEventListener('focus', onFocus)
+    }
+  }, [refresh])
+
+  const unreadCount = friendRequests.length
+
+  return { friendRequests, unreadCount, loading, refresh }
+}


### PR DESCRIPTION
## 概要
ヘッダーに通知ベルと未読バッジを追加し、受け取ったフレンド申請をその場で承認/拒否できるようにする（#50 の段階的実装、第一歩）。

issue #50 の「まずメール/アプリ内通知（未読バッジ）」に相当。新テーブルやマイグレーションは不要で、既存の `friend_requests` を利用。

## 変更点
- **`useNotifications` フック**: 受け取った pending フレンド申請を取得。30秒ポーリング＋タブ復帰（focus）時に再取得して未読件数を更新
- **`NotificationBell`**: ベルアイコン＋未読バッジ。Popover で申請一覧を表示し、`accept_friend_request` RPC で承認 / 削除で拒否。空状態も表示
- **MainLayout** のヘッダー（アバター左）に常設

## 動作確認
- `npm run build` / `tsc --noEmit` / `eslint` クリーン
- ログイン済みプレビューでベルとポップオーバー表示を確認（申請なし時は空状態）

## 今後（#50 の残り）
- 通知の種別拡張（予定共有 / 「誰かが位置を共有」など）を同じ仕組みに集約
- メール通知、Web Push + PWA 化（manifest / service worker）
- 予定リマインダーのトースト（#66, PR #74）との統合

関連: #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)