### PR TITLE
fix(test): main のビルド破綻を修正（recurrence フィクスチャ欠落）

### DIFF
--- a/src/components/Calendar/calendarUtils.test.ts
+++ b/src/components/Calendar/calendarUtils.test.ts
@@ -27,6 +27,8 @@ function makeEvent(overrides: Partial<EventRow> & { startAt: string; endAt: stri
     isAllDay: overrides.isAllDay ?? false,
     eventLocation: overrides.eventLocation ?? null,
     sharingState: overrides.sharingState ?? 'team',
+    recurrence: overrides.recurrence ?? 'none',
+    recurrenceEndDate: overrides.recurrenceEndDate ?? null,
     createdAt: overrides.createdAt ?? null,
     startAt: overrides.startAt,
     endAt: overrides.endAt,


### PR DESCRIPTION
## 緊急: main のビルド破綻修正

#64(テスト) と #65(繰り返し) が個別にはマージ可能でも、組み合わさると `calendarUtils.test.ts` の `makeEvent` が `recurrence` / `recurrenceEndDate` を欠いて `tsc` が失敗していました（main が現在ビルド不能）。

両フィールドを既定値（`'none'` / `null`）付きで追加。ローカルで `npm run build` 成功を確認。

**最優先でマージ推奨**です。🤖 Generated with [Claude Code](https://claude.com/claude-code)