### PR TITLE
feat(notifications): 新しい予定のアプリ内通知を追加（#50）

### DIFF
--- a/src/components/Notifications/NotificationBell.tsx
+++ b/src/components/Notifications/NotificationBell.tsx
@@ -19,10 +19,24 @@ import {
 import { supabase } from '../../lib/supabase'
 import { useNotifications } from '../../hooks/useNotifications'
 
+/** 予定の開始日時を短く表示する（例: 6/30 14:00）。 */
+function formatEventStart(startAt: string): string {
+  const d = new Date(startAt)
+  if (Number.isNaN(d.getTime())) return ''
+  return d.toLocaleString('ja-JP', {
+    month: 'numeric',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
 export function NotificationBell({ userId }: { userId: string | undefined }) {
-  const { friendRequests, unreadCount, refresh } = useNotifications(userId)
+  const { friendRequests, events, unreadCount, refresh, markEventsSeen } = useNotifications(userId)
   const toast = useToast()
   const [busyId, setBusyId] = useState<string | null>(null)
+
+  const isEmpty = friendRequests.length === 0 && events.length === 0
 
   async function accept(requestId: string, name: string) {
     setBusyId(requestId)
@@ -50,7 +64,7 @@ export function NotificationBell({ userId }: { userId: string | undefined }) {
   }
 
   return (
-    <Popover placement="bottom-end" isLazy>
+    <Popover placement="bottom-end" isLazy onOpen={markEventsSeen}>
       <PopoverTrigger>
         <Box position="relative" display="inline-flex">
           <IconButton
@@ -87,7 +101,7 @@ export function NotificationBell({ userId }: { userId: string | undefined }) {
           通知
         </PopoverHeader>
         <PopoverBody px={2} py={2} maxH="360px" overflowY="auto">
-          {friendRequests.length === 0 ? (
+          {isEmpty ? (
             <Center py={8}>
               <Text fontSize="sm" color="gray.500">
                 新しい通知はありません
@@ -95,6 +109,7 @@ export function NotificationBell({ userId }: { userId: string | undefined }) {
             </Center>
           ) : (
             <VStack align="stretch" spacing={1}>
+              {/* フレンド申請（actionable） */}
               {friendRequests.map((n) => (
                 <Box key={n.requestId} px={2} py={2} borderRadius="md" _hover={{ bg: 'gray.50' }}>
                   <HStack spacing={3} align="start">
@@ -125,6 +140,36 @@ export function NotificationBell({ userId }: { userId: string | undefined }) {
                         </Button>
                       </HStack>
                     </Box>
+                  </HStack>
+                </Box>
+              ))}
+
+              {/* 新しい予定（情報通知） */}
+              {events.map((e) => (
+                <Box key={e.eventId} px={2} py={2} borderRadius="md" _hover={{ bg: 'gray.50' }}>
+                  <HStack spacing={3} align="start">
+                    <Center boxSize="32px" borderRadius="full" bg="primary.50" flexShrink={0}>
+                      <Box as="span" fontSize="md">
+                        📅
+                      </Box>
+                    </Center>
+                    <Box minW={0} flex={1}>
+                      <Text fontSize="sm" color="gray.800">
+                        <Text as="span" fontWeight="600">
+                          {e.creator.displayName}
+                        </Text>{' '}
+                        さんが予定を追加
+                      </Text>
+                      <Text fontSize="sm" color="gray.700" noOfLines={1}>
+                        {e.name}
+                      </Text>
+                      <Text fontSize="xs" color="gray.500" mt={0.5}>
+                        {formatEventStart(e.startAt)}
+                      </Text>
+                    </Box>
+                    {e.unread && (
+                      <Box boxSize="8px" borderRadius="full" bg="danger.500" mt={1} flexShrink={0} />
+                    )}
                   </HStack>
                 </Box>
               ))}

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { supabase } from '../lib/supabase'
 
 export interface FriendRequestNotification {
@@ -7,45 +7,103 @@ export interface FriendRequestNotification {
   createdAt: string | null
 }
 
+export interface EventNotification {
+  eventId: string
+  name: string
+  startAt: string
+  createdAt: string | null
+  creator: { id: string; displayName: string }
+  /** 最終閲覧時刻より後に作成された＝未読か。 */
+  unread: boolean
+}
+
 const POLL_MS = 30_000
+// 予定通知の対象は直近のみ（古い予定を延々と通知しない）。
+const EVENT_LOOKBACK_DAYS = 30
+const EVENT_LIMIT = 20
+
+/** 予定通知の「最終閲覧時刻」を保存する localStorage キー。ユーザー単位。 */
+function eventsSeenKey(userId: string) {
+  return `notif:eventsLastSeen:${userId}`
+}
+
+function readEventsLastSeen(userId: string): string {
+  const stored = localStorage.getItem(eventsSeenKey(userId))
+  if (stored) return stored
+  // 初回はその時点を基準にし、過去の予定で通知を溢れさせない
+  // （以降に作成された予定だけを「新着」として扱う）。
+  const now = new Date().toISOString()
+  localStorage.setItem(eventsSeenKey(userId), now)
+  return now
+}
 
 /**
- * アプリ内通知。現状は「受け取ったフレンド申請」を扱う。
- * 起動中は定期ポーリング＋タブ復帰時に再取得して未読件数を更新する。
- * 将来 #50 で予定共有・位置共有などの通知も同じ仕組みに集約できる。
+ * アプリ内通知。受け取ったフレンド申請（actionable）に加え、自分の所属
+ * チームで他人が作成した新しい予定（#50）を扱う。起動中は定期ポーリング＋
+ * タブ復帰時に再取得して未読件数を更新する。
+ *
+ * 予定の「未読」は localStorage の最終閲覧時刻で判定する（DB スキーマ変更なし）。
+ * フレンド申請は対応するまで常に未読扱い。
  */
 export function useNotifications(userId: string | undefined) {
   const [friendRequests, setFriendRequests] = useState<FriendRequestNotification[]>([])
+  // 取得済みの予定（未読フラグは lastSeen から都度算出する）。
+  const [eventRows, setEventRows] = useState<Omit<EventNotification, 'unread'>[]>([])
+  const [lastSeen, setLastSeen] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
+  // refresh が lastSeen 変化で作り直されないよう ref で参照する。
+  const lastSeenRef = useRef<string | null>(null)
+  lastSeenRef.current = lastSeen
 
   const refresh = useCallback(async () => {
     if (!userId) {
       setFriendRequests([])
+      setEventRows([])
       return
     }
     setLoading(true)
     try {
-      const { data: reqs } = await supabase
-        .from('friend_requests')
-        .select('id, requesterId, createdAt')
-        .eq('addresseeId', userId)
-        .eq('status', 'pending')
-        .order('createdAt', { ascending: false })
+      const since = new Date(Date.now() - EVENT_LOOKBACK_DAYS * 24 * 60 * 60 * 1000).toISOString()
 
-      const rows = reqs ?? []
-      if (rows.length === 0) {
-        setFriendRequests([])
-        return
+      // フレンド申請と新着予定を並行取得。
+      const [{ data: reqs }, { data: evRows }] = await Promise.all([
+        supabase
+          .from('friend_requests')
+          .select('id, requesterId, createdAt')
+          .eq('addresseeId', userId)
+          .eq('status', 'pending')
+          .order('createdAt', { ascending: false }),
+        // RLS の events_select により自分の所属チームの予定のみ返る。
+        // 自分が作成したものは除外。
+        supabase
+          .from('events')
+          .select('id, name, startAt, createdBy, createdAt')
+          .neq('createdBy', userId)
+          .gte('createdAt', since)
+          .order('createdAt', { ascending: false })
+          .limit(EVENT_LIMIT),
+      ])
+
+      const reqRows = reqs ?? []
+      const events = evRows ?? []
+
+      // 申請者・作成者の表示名をまとめて引く。
+      const userIds = [
+        ...reqRows.map((r) => r.requesterId),
+        ...events.map((e) => e.createdBy),
+      ]
+      const uniqueIds = [...new Set(userIds)]
+      const byId = new Map<string, { id: string; displayName: string; email: string }>()
+      if (uniqueIds.length > 0) {
+        const { data: users } = await supabase
+          .from('users')
+          .select('id, displayName, email')
+          .in('id', uniqueIds)
+        for (const u of users ?? []) byId.set(u.id, u)
       }
-      const ids = rows.map((r) => r.requesterId)
-      const { data: users } = await supabase
-        .from('users')
-        .select('id, displayName, email')
-        .in('id', ids)
-      const byId = new Map((users ?? []).map((u) => [u.id, u]))
 
       setFriendRequests(
-        rows.map((r) => ({
+        reqRows.map((r) => ({
           requestId: r.id,
           createdAt: r.createdAt,
           requester: byId.get(r.requesterId) ?? {
@@ -55,9 +113,31 @@ export function useNotifications(userId: string | undefined) {
           },
         })),
       )
+
+      setEventRows(
+        events.map((e) => {
+          const creator = byId.get(e.createdBy)
+          return {
+            eventId: e.id,
+            name: e.name,
+            startAt: e.startAt,
+            createdAt: e.createdAt,
+            creator: { id: e.createdBy, displayName: creator?.displayName ?? '不明なユーザー' },
+          }
+        }),
+      )
     } finally {
       setLoading(false)
     }
+  }, [userId])
+
+  // userId 確定時に lastSeen を読み込む（初回は now を保存）。
+  useEffect(() => {
+    if (!userId) {
+      setLastSeen(null)
+      return
+    }
+    setLastSeen(readEventsLastSeen(userId))
   }, [userId])
 
   useEffect(() => {
@@ -71,7 +151,27 @@ export function useNotifications(userId: string | undefined) {
     }
   }, [refresh])
 
-  const unreadCount = friendRequests.length
+  // 予定に未読フラグを付与。
+  const events = useMemo<EventNotification[]>(
+    () =>
+      eventRows.map((e) => ({
+        ...e,
+        unread: Boolean(lastSeen && e.createdAt && e.createdAt > lastSeen),
+      })),
+    [eventRows, lastSeen],
+  )
 
-  return { friendRequests, unreadCount, loading, refresh }
+  const unreadEventCount = events.filter((e) => e.unread).length
+  // 申請は常に未読扱い（対応するまで残る）。
+  const unreadCount = friendRequests.length + unreadEventCount
+
+  /** 予定通知を既読にする（ベルを開いた時などに呼ぶ）。 */
+  const markEventsSeen = useCallback(() => {
+    if (!userId) return
+    const now = new Date().toISOString()
+    localStorage.setItem(eventsSeenKey(userId), now)
+    setLastSeen(now)
+  }, [userId])
+
+  return { friendRequests, events, unreadCount, unreadEventCount, loading, refresh, markEventsSeen }
 }


### PR DESCRIPTION
## 概要
通知ベル（PR #75）を拡張し、**自分の所属チームで他人が作成した新しい予定**をアプリ内通知に追加する（#50 の段階的実装）。
新テーブル・マイグレーションは不要で、既存の `events` を RLS 経由で取得して導出する。

## 変更点
- **`useNotifications`**: フレンド申請に加え `events` から新着予定を取得（自分の作成分は除外、直近30日・最大20件）。予定の未読は **localStorage の最終閲覧時刻** で判定（DB変更なし）。`markEventsSeen()` でベルを開いた時に既読化。`unreadCount` は申請数＋未読予定数
- **`NotificationBell`**: 予定通知の表示（作成者・予定名・開始日時・未読ドット）と `onOpen` での既読化。空状態は両方空のとき

## 動作確認
- `npm run lint` クリーン / `npm run build` 成功
- 未ログイン画面でコンソールエラー0（共有バンドルにリグレッション無し）を確認
- ⚠️ 通知ベルはログイン後ヘッダーに表示されるため、ベルの操作確認はレビュー側でお願いします（ログイン/認証情報の都合で自動検証は未ログイン読み込みまで）

## スコープ外（#50 の残り）
- **位置共有通知**: `locations` は1ユーザー1行のインプレース更新で「共有開始」履歴を持たないため、検出にはスキーマ変更が必要。別対応
- メール通知 / Web Push + PWA 化

Refs #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)