### PR TITLE
chore(docs): .env を .env.local へ移行し、CLAUDE.md を実態に合わせる

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,10 +2,10 @@
 # 環境変数のサンプル
 # ------------------------------------------------------------
 # 使い方:
-#   1. このファイルをコピーして「.env」という名前で保存する
-#        cp .env.example .env        (Windows: copy .env.example .env)
+#   1. このファイルをコピーして「.env.local」という名前で保存する
+#        cp .env.example .env.local  (Windows: copy .env.example .env.local)
 #   2. 下の値を自分の Supabase プロジェクトのものに書き換える
-#   3. npm run dev を再起動する（.env は起動時に読み込まれる）
+#   3. npm run dev を再起動する（起動時に読み込まれる）
 #
 # 値の場所: Supabase ダッシュボード → 対象プロジェクト
 #   → Project Settings → API
@@ -13,8 +13,14 @@
 #     - Project API keys / anon → VITE_SUPABASE_ANON_KEY
 #
 # 注意:
-#   - 「.env」本体は Git にコミットしない（.gitignore 済み）。
+#   - 「.env.local」本体は Git にコミットしない（.gitignore 済み）。
 #   - これが無いと画面が真っ白になる（接続先が分からず起動に失敗するため）。
+#   - 「.env」ではなく「.env.local」を使うこと。
+#     .env は過去に Git 追跡されており、古いブランチ 26 本が今も .env を
+#     ツリーに持っている。そのため main と古いブランチを git checkout で
+#     行き来すると、ディスク上の .env が git に削除されてしまう。
+#     .env.local はどのブランチも追跡していないので、この事故が起きない。
+#     Vite は .env.local を優先して読むため、他の設定変更は不要。
 #   - 本番(Vercel)では、このファイルではなく Vercel の
 #     Environment Variables に同じ2つを登録する。
 # ============================================================

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,8 +43,11 @@ Schema defined in `supabase/migrations/0001_init.sql`. Key tables:
 | Table | Purpose |
 |---|---|
 | `users` | Linked to `auth.users` via trigger on signup |
-| `teams` | Groups with unique `invitationalCode` |
+| `teams` | Groups with unique `invitationalCode` and `removalPolicy` |
 | `user_teams` | Many-to-many with `role` (admin/member) |
+| `team_invitations` | Team invites awaiting the invitee's consent |
+| `team_messages` | Talk room messages; deleted after 30 days |
+| `friend_requests` | Friend requests awaiting approval |
 | `user_friends` | Bidirectional friendship pairs |
 | `events` | Calendar events scoped to team with `sharingState` |
 | `locations` | One row per user, updated in-place; Realtime enabled |
@@ -53,14 +56,28 @@ Schema defined in `supabase/migrations/0001_init.sql`. Key tables:
 
 RLS is enabled on all tables. Auth trigger `handle_new_user()` auto-inserts into `public.users` on signup.
 
+### Team membership rules (`0012`)
+
+`user_teams` の RLS は自分の行しか見えないため、メンバー一覧・招待・追放・退出はすべて `SECURITY DEFINER` の RPC 経由で行う（`list_team_members` / `invite_team_member` / `accept_team_invitation` / `remove_team_member` / `leave_team` など）。
+
+- **参加は必ず本人の同意が要る。** 他人を直接 `user_teams` へ入れる関数は無い。招待を出し、招待された本人が承諾して初めて参加する
+- 例外は招待コード参加（`join_team_by_code`）。本人がコードを入力する操作なので同意済みとみなす
+- 誰が他メンバーを追放できるかは `teams."removalPolicy"`（`admin_only` / `anyone` / `nobody`）で決まる。チーム作成時に決定し、あとから変更する導線は無い
+- `is_team_member` / `is_team_admin` は内部ヘルパで、`authenticated` から `REVOKE` 済み（membership oracle を防ぐため）。**新しい RPC を足すときも GRANT しないこと**
+
+### Migrations
+
+番号のプレフィックスが Supabase の履歴テーブルの主キーになるため、**番号を重複させないこと**。過去に `0007` と `0008` が重複し、片方が履歴に記録されず `db push` が通らなくなった（`0013` / `0014` へリナンバーして解消）。
+
 ## GitHub Workflows
 
 ### CI (`ci.yml`)
 
-`pull_request` to `main` でトリガー。`frontend/` ディレクトリを作業ディレクトリとして Lint → Build を実行。
-> 注意: CI の `working-directory` が `frontend` になっているが、現状リポジトリルートに直接ソースがある。CI が失敗する場合はこの設定を確認すること。
+`pull_request` to `main` でトリガー。リポジトリルートで Install → Lint → Build → Test を実行する。
 
-テストステップはコメントアウト済み（追加時に有効化）。
+テストは `npm test`（`vitest run --project unit`）。現状テストファイルは `src/components/Calendar/calendarUtils.test.ts` の 1 本のみで、認証・RLS・チーム権限のテストは無い。
+
+バックエンド用ジョブは `ci.yml` にコメントアウトで雛形が残っている（バックエンド導入時に有効化）。
 
 ### Issue テンプレート
 
@@ -77,4 +94,6 @@ RLS is enabled on all tables. Auth trigger `handle_new_user()` auto-inserts into
 
 ## Environment
 
-Copy `.env.example` to `.env` and fill in your Supabase project URL and anon key.
+Copy `.env.example` to **`.env.local`** and fill in your Supabase project URL and anon key.
+
+> **`.env` ではなく `.env.local` を使うこと。** `.env` は過去に追跡されており（`4d6f8ea` で untrack）、古いブランチ 26 本が今も `.env` をツリーに持っている。gitignore は「切替先のコミットが追跡しているファイル」を守れないため、それらのブランチと `main` を `git checkout` で行き来すると**ディスク上の `.env` が消える**。`.env.local` はどのブランチも追跡していないので、この問題が起きない。Vite は `.env.local` を優先して読むため設定変更は不要。


### PR DESCRIPTION
## 概要

`.env` がブランチ切替でディスクから消える事故への恒久対策と、`CLAUDE.md` の古くなった記述の修正です。

## `.env` が消える原因

`.env` は `.gitignore` に入っていますが、**gitignore は「切替先のコミットが追跡しているファイル」を守れません。**

`.env` は過去に Git 追跡されており、`4d6f8ea`（#45 セキュリティ対応）で untrack されました。しかし**古いブランチ 26 本が今も `.env` をツリーに持ったまま**です。そのため、それらのブランチと `main` を `git checkout` で行き来すると、git が「切替先に .env が無い」と判断してディスク上の `.env` を削除します。新しい側では gitignore 扱いなので復元もされません。

未マージのまま `.env` を持っているブランチ:

- `origin/claude/app-status-vision-6hm11z`
- `origin/feat/event-edit`
- `origin/feature/calendar-slot-quick-add`
- `origin/feature/team-chat-and-event-edit`
- `origin/feature/team-member-locations`

## 対策

**`.env.local` を使う。** `.env.local` はどのブランチも追跡していないため（確認済み・0件）、この事故が構造的に起こりません。Vite は `.env.local` を `.env` より優先して読むので、コード側の変更は不要です。

## 🔴 各自やってほしいこと

このPRはドキュメントを直すだけです。**手元のファイルは各自でリネームしてください。**

```bash
mv .env .env.local
```

Windows の場合:

```
ren .env .env.local
```

リネーム後 `npm run dev` を再起動すれば、これまで通り動きます。以降ブランチを切り替えても消えません。

## CLAUDE.md の修正

実態と食い違っていた記述を直しました。

- **CI**: 「`working-directory` が `frontend` になっていて失敗する」という注意書きを削除。現在の `ci.yml` にその記述は無く、Lint / Build / Test が通っています
- **DB テーブル表**: `team_invitations` / `team_messages` / `friend_requests` が抜けていたので追加
- **チームのメンバー管理ルール（0012）を追記**: 参加は本人の同意が必須、`removalPolicy` の意味、`is_team_member` は GRANT しないこと
- **マイグレーション番号の重複に関する注意を追記**: 過去に `0007` / `0008` が重複して `db push` が通らなくなった経緯

## 確認

- [x] `npm run lint`
- [x] `npm run build`
- [x] `.env.local` から環境変数が読めることを dev サーバーで確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
