### PR TITLE
feat(monitoring): Sentry エラートラッキングを導入（#52）

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,3 +21,25 @@
 
 VITE_SUPABASE_URL=https://your-project-id.supabase.co
 VITE_SUPABASE_ANON_KEY=your-anon-key
+
+# ============================================================
+# エラートラッキング（Sentry）— 任意
+# ------------------------------------------------------------
+#   - 下の DSN を設定したときだけ Sentry が有効になる（未設定なら無効）。
+#     値の場所: Sentry → 対象プロジェクト → Settings → Client Keys (DSN)
+#   - 本番(Vercel)では Vercel の Environment Variables に登録する。
+#   - DSN はブラウザに露出してよい公開値（anon key と同様）。
+# ============================================================
+# VITE_SENTRY_DSN=https://xxxxx@oyyyy.ingest.sentry.io/zzzzz
+
+# リリースタグ（任意）。どのデプロイで起きたかを紐付ける。
+# Vercel では VERCEL_GIT_COMMIT_SHA を渡すと良い。
+# VITE_SENTRY_RELEASE=
+
+# --- ソースマップのアップロード（ビルド時のみ・任意） -------------------
+# 以下を設定したビルドだけ、Sentry にソースマップをアップロードして
+# 本番スタックトレースを元コードに復元できるようにする（未設定ならスキップ）。
+# これらはブラウザには露出しない（VITE_ プレフィックスを付けないこと）。
+#   SENTRY_AUTH_TOKEN=   # Sentry → Settings → Auth Tokens で発行
+#   SENTRY_ORG=          # 組織スラッグ
+#   SENTRY_PROJECT=      # プロジェクトスラッグ

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@chakra-ui/react": "^2.10.9",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
+        "@sentry/react": "^10.62.0",
         "@supabase/supabase-js": "^2.99.2",
         "framer-motion": "^12.37.0",
         "leaflet": "^1.9.4",
@@ -22,6 +23,7 @@
       "devDependencies": {
         "@chromatic-com/storybook": "^5.0.1",
         "@eslint/js": "^9.39.4",
+        "@sentry/vite-plugin": "^5.3.0",
         "@storybook/addon-a11y": "^10.2.19",
         "@storybook/addon-docs": "^10.2.19",
         "@storybook/addon-onboarding": "^10.2.19",
@@ -1696,6 +1698,330 @@
         }
       }
     },
+    "node_modules/@sentry/browser": {
+      "version": "10.70.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.70.0.tgz",
+      "integrity": "sha512-IK6+J+8H06tZe+A8L37TT5ZxxwNtyQatW8zl5RYYJ/e9CsjrM8fPi8I1OT7uquTw8UtjqFHt7bEef/Vy63ksPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser-utils": "10.70.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.70.0",
+        "@sentry/feedback": "10.70.0",
+        "@sentry/replay": "10.70.0",
+        "@sentry/replay-canvas": "10.70.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/browser-utils": {
+      "version": "10.70.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser-utils/-/browser-utils-10.70.0.tgz",
+      "integrity": "sha512-IvjhafF5NFXrPCg5EHbAPGDwIhHxgUcLlHTklZ3DAdA6ky88BJYMfevbcnOEmgavf4nylhCaquRUFNB5+szj+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.70.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/bundler-plugins": {
+      "version": "10.70.0",
+      "resolved": "https://registry.npmjs.org/@sentry/bundler-plugins/-/bundler-plugins-10.70.0.tgz",
+      "integrity": "sha512-M+a32VOZVeTUxF+QecQ+OHYj8hb5FeppKwwWpTQ9cfS6ixgoNUK7/B7NhB2XbfxE3F1BcGvOxyS+AB+fvPfSRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.18.5",
+        "@sentry/cli": "^2.58.6",
+        "@sentry/core": "10.70.0",
+        "dotenv": "^17.4.2",
+        "find-up": "^5.0.0",
+        "glob": "^13.0.6",
+        "magic-string": "~0.30.8"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "rollup": ">=3.2.0",
+        "webpack": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        },
+        "webpack": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sentry/cli": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.58.6.tgz",
+      "integrity": "sha512-baBcNPLLfUi9WuL+Tpri9BFaAdvugZIKelC5X0tt0Zdy+K0K+PCVSrnNmwMWU/HyaF/SEv6b6UHnXIdqanBlcg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "FSL-1.1-MIT",
+      "dependencies": {
+        "https-proxy-agent": "^5.0.0",
+        "node-fetch": "^2.6.7",
+        "progress": "^2.0.3",
+        "proxy-from-env": "^1.1.0",
+        "which": "^2.0.2"
+      },
+      "bin": {
+        "sentry-cli": "bin/sentry-cli"
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@sentry/cli-darwin": "2.58.6",
+        "@sentry/cli-linux-arm": "2.58.6",
+        "@sentry/cli-linux-arm64": "2.58.6",
+        "@sentry/cli-linux-i686": "2.58.6",
+        "@sentry/cli-linux-x64": "2.58.6",
+        "@sentry/cli-win32-arm64": "2.58.6",
+        "@sentry/cli-win32-i686": "2.58.6",
+        "@sentry/cli-win32-x64": "2.58.6"
+      }
+    },
+    "node_modules/@sentry/cli-darwin": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-2.58.6.tgz",
+      "integrity": "sha512-udAVvcyfNa0R+95GvPz/+43/N3TC0TYKdkQ7D7jhPSzbcMc7l2fxRNN5yB3UpCA5fWFnW4toeaqwDBhb/Wh3LA==",
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-arm": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-2.58.6.tgz",
+      "integrity": "sha512-pD0LAt5PcUzAinBwvDqc66x9+2CabHEv486yP0gRjWO7SakbaxmfVq/EXd8VLq/Tzi39LAu422UYK1lpW3MILw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-arm64": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm64/-/cli-linux-arm64-2.58.6.tgz",
+      "integrity": "sha512-q8mEcNNmeXMy5i+jWT30TVpH7LcP4HD21CD5XRSPAd/a912HF6EpK0ybf/1USO14WOhoXbAGi9txwaWabSe33g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-i686": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-i686/-/cli-linux-i686-2.58.6.tgz",
+      "integrity": "sha512-q8vNJi1eOV/4vxAFWBsEwLHoSYapaZHIf4j76KJGJXFKTkEbsjCOOsKbwUIBTQQhRgV4DFWh3ryfsPS/que4Kg==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-x64": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-2.58.6.tgz",
+      "integrity": "sha512-DZu956Mhi3ZRjTBe1WdbGV46ldVbA8d2rgp/fh51GsI25zjBHah4wZnPTSzpc+YqxU6pJpg579B/r3jrIK530Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-arm64": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-arm64/-/cli-win32-arm64-2.58.6.tgz",
+      "integrity": "sha512-nj0Ff/kmAB73EPDhR8B4O9r+NUHK5GkPCkGWC+kXVemqAJWL5jcJ5KdxG0l/S0z6RoEoltID8/43/B+TaMlT7A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-i686": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-2.58.6.tgz",
+      "integrity": "sha512-WNZiDzPbgsEMQWq4avsQ391v/xWKJDIWWWo9GYl+N/w5qcYKkoDW7wQG7T9FasI6ENn68phChTOAPXXxbfAdOg==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-x64": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-2.58.6.tgz",
+      "integrity": "sha512-R35WJ17oF4D2eqI1DR2sQQqr0fjRTt5xoP16WrTu91XM2lndRMFsnjh+/GttbxapLCBNlrjzia99MJ0PZHZpgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/conventions": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@sentry/conventions/-/conventions-0.16.0.tgz",
+      "integrity": "sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.70.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.70.0.tgz",
+      "integrity": "sha512-ozhCTDqg89oB4XmWfAwuHshABpvT7AkRpaPnogopPfMAaI61G1t8EKCJ4W7aum8JSBonlfyjPCyW5oYZFm0KvA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/feedback": {
+      "version": "10.70.0",
+      "resolved": "https://registry.npmjs.org/@sentry/feedback/-/feedback-10.70.0.tgz",
+      "integrity": "sha512-6VQn2ETJjHkk4QQDdx/587/JDfXsk3yBTLZ3UZOMtBVrkmwgk+1FJZ8ULJ3ud1xZcuh2icunIkc7tGVv2axdnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.70.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/react": {
+      "version": "10.70.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.70.0.tgz",
+      "integrity": "sha512-j1d/4hvoaUVKs5GRrfmwUCkiEmkfaeHsk+xgausZlzg5YvmwpF+gyevBLNP26GFEH7nyHXW4l8dbbo0eNieJmw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser": "10.70.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.70.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || 17.x || 18.x || 19.x"
+      }
+    },
+    "node_modules/@sentry/replay": {
+      "version": "10.70.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-10.70.0.tgz",
+      "integrity": "sha512-xMnSGzJn9Xd29rYd32lkx/gFW+5mtgqADJ2FiZvis0MBGZuDlNRwPn0/Cs1xA3JNXKV3NGfhdmmvs90w4dHSmw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser-utils": "10.70.0",
+        "@sentry/core": "10.70.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/replay-canvas": {
+      "version": "10.70.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay-canvas/-/replay-canvas-10.70.0.tgz",
+      "integrity": "sha512-irzpw22bK5CF3jbecDa0gBUcfjv7tgeUoLAvtIfeHOP5ajmf3o4Cp99a9RQqkfgvkcMeRZBUwE91SQhp6Ank+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.70.0",
+        "@sentry/replay": "10.70.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/vite-plugin": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@sentry/vite-plugin/-/vite-plugin-5.4.0.tgz",
+      "integrity": "sha512-fFJgCxs5hDyAm9BbZJ+LbA+LK2tjX5OoD0v0ARU4StR6KQmGUduoPs69yJ9AfqZ0om3Rlp5JDliiwFcNkasORA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/bundler-plugins": "^10.64.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -2914,6 +3240,19 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
@@ -3468,6 +3807,19 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.313",
@@ -4143,6 +4495,20 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/iceberg-js": {
       "version": "0.8.1",
@@ -4941,6 +5307,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.36",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
@@ -5299,6 +5686,16 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -5309,6 +5706,13 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -5969,6 +6373,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ts-api-utils": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
@@ -6379,12 +6790,30 @@
         "node": ">=18"
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/webpack-virtual-modules": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
       "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@chakra-ui/react": "^2.10.9",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
+    "@sentry/react": "^10.62.0",
     "@supabase/supabase-js": "^2.99.2",
     "framer-motion": "^12.37.0",
     "leaflet": "^1.9.4",
@@ -28,6 +29,7 @@
   "devDependencies": {
     "@chromatic-com/storybook": "^5.0.1",
     "@eslint/js": "^9.39.4",
+    "@sentry/vite-plugin": "^5.3.0",
     "@storybook/addon-a11y": "^10.2.19",
     "@storybook/addon-docs": "^10.2.19",
     "@storybook/addon-onboarding": "^10.2.19",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,14 +1,18 @@
 import { ChakraProvider } from '@chakra-ui/react'
+import * as Sentry from '@sentry/react'
 import theme from './theme/theme'
 import { AuthGuard } from './components/AuthGuard'
 import { MainLayout } from './components/Layout/MainLayout'
+import { ErrorFallback } from './components/ErrorFallback'
 
 function App() {
   return (
     <ChakraProvider theme={theme}>
-      <AuthGuard>
-        <MainLayout />
-      </AuthGuard>
+      <Sentry.ErrorBoundary fallback={({ resetError }) => <ErrorFallback resetError={resetError} />}>
+        <AuthGuard>
+          <MainLayout />
+        </AuthGuard>
+      </Sentry.ErrorBoundary>
     </ChakraProvider>
   )
 }

--- a/src/components/ErrorFallback.tsx
+++ b/src/components/ErrorFallback.tsx
@@ -1,0 +1,42 @@
+import { Box, Button, Heading, Text, VStack } from '@chakra-ui/react'
+
+interface ErrorFallbackProps {
+  /** Sentry.ErrorBoundary が渡す、境界をリセットして再描画を試みる関数。 */
+  resetError: () => void
+}
+
+/**
+ * 未捕捉エラーで描画が落ちた際に表示する画面。Sentry.ErrorBoundary の
+ * fallback として使う。ChakraProvider の内側に置くこと（Chakra コンポーネントを使うため）。
+ */
+export function ErrorFallback({ resetError }: ErrorFallbackProps) {
+  return (
+    <Box
+      minH="100vh"
+      display="flex"
+      alignItems="center"
+      justifyContent="center"
+      p={6}
+    >
+      <VStack spacing={4} textAlign="center" maxW="md">
+        <Heading size="md" fontFamily="heading">
+          問題が発生しました
+        </Heading>
+        <Text color="gray.600">
+          予期しないエラーが発生しました。お手数ですが、もう一度お試しください。
+          問題が続く場合はしばらくしてから再度アクセスしてください。
+        </Text>
+        <Button
+          colorScheme="primary"
+          onClick={() => {
+            // まず境界をリセットして再描画を試み、ダメなら全体リロード。
+            resetError()
+            window.location.reload()
+          }}
+        >
+          再読み込み
+        </Button>
+      </VStack>
+    </Box>
+  )
+}

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -8,6 +8,7 @@ import {
 } from 'react'
 import type { User, Session, AuthError } from '@supabase/supabase-js'
 import { supabase } from '../lib/supabase'
+import { setSentryUser } from '../lib/sentry'
 import type { Database } from '../types/database'
 
 type Profile = Database['public']['Tables']['users']['Row']
@@ -102,6 +103,7 @@ function useProvideAuth() {
       setSession(session)
       setUser(session?.user ?? null)
       setLoading(false)
+      setSentryUser(session?.user?.id ?? null)
       fetchProfileAndTeams(session?.user?.id)
     })
 
@@ -109,6 +111,7 @@ function useProvideAuth() {
       if (event === 'PASSWORD_RECOVERY') setPasswordRecovery(true)
       setSession(session)
       setUser(session?.user ?? null)
+      setSentryUser(session?.user?.id ?? null)
       fetchProfileAndTeams(session?.user?.id)
     })
 

--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -1,0 +1,44 @@
+import * as Sentry from '@sentry/react'
+
+// 実行時の DSN。未設定（ローカル開発や DSN を登録していない環境）では
+// Sentry を一切初期化せず no-op にする。これにより .env が無くても
+// 開発・テストが妨げられない。
+const dsn = import.meta.env.VITE_SENTRY_DSN as string | undefined
+
+/** Sentry が有効化されているか（DSN が設定されているか）。 */
+export const sentryEnabled = Boolean(dsn)
+
+/**
+ * Sentry を初期化する。`main.tsx` で描画前に一度だけ呼ぶ。
+ * 現状はエラー収集（未捕捉例外）のみ。パフォーマンス追跡・セッション
+ * リプレイは未使用なので、対応する integration を読み込まずバンドルを
+ * 最小限に保つ。将来有効化する場合は `integrations` と `tracesSampleRate`
+ * を追加する。
+ */
+export function initSentry() {
+  if (!dsn) return
+
+  Sentry.init({
+    dsn,
+    // 'production' / 'development' など Vite のモードをそのまま使う。
+    environment: import.meta.env.MODE,
+    // どのデプロイで起きたかを紐付けるリリースタグ（任意）。
+    // ビルド時に VITE_SENTRY_RELEASE（例: コミット SHA）を渡すと有効。
+    release: (import.meta.env.VITE_SENTRY_RELEASE as string | undefined) || undefined,
+    // メール等の PII を自動付与しない。ユーザー識別は setSentryUser で
+    // 最小限（ID のみ）を明示的に送る。
+    sendDefaultPii: false,
+    // エラー収集のみ。トレースは無効（= 課金対象のパフォーマンス計測なし）。
+    tracesSampleRate: 0,
+  })
+}
+
+/**
+ * 発生したエラーをどのユーザーのものか紐付ける。
+ * プライバシー配慮のためメール等は送らず ID のみ。サインアウト時は
+ * null を渡してクリアする。
+ */
+export function setSentryUser(userId: string | null) {
+  if (!dsn) return
+  Sentry.setUser(userId ? { id: userId } : null)
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,10 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
 import { AuthProvider } from './hooks/useAuth'
+import { initSentry } from './lib/sentry'
+
+// 描画前にエラートラッキングを初期化（DSN 未設定なら no-op）。
+initSentry()
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,7 @@
 /// <reference types="vitest/config" />
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import { sentryVitePlugin } from '@sentry/vite-plugin';
 
 // https://vite.dev/config/
 import path from 'node:path';
@@ -9,9 +10,40 @@ import { storybookTest } from '@storybook/addon-vitest/vitest-plugin';
 import { playwright } from '@vitest/browser-playwright';
 const dirname = typeof __dirname !== 'undefined' ? __dirname : path.dirname(fileURLToPath(import.meta.url));
 
+// Sentry へのソースマップアップロードに必要な認証情報（ビルド時のみ・
+// VITE_ プレフィックス無し = ブラウザには露出しない）。
+const sentryAuthToken = process.env.SENTRY_AUTH_TOKEN;
+const sentryOrg = process.env.SENTRY_ORG;
+const sentryProject = process.env.SENTRY_PROJECT;
+// 実行時の release（VITE_SENTRY_RELEASE）と一致させる。Vercel では
+// VERCEL_GIT_COMMIT_SHA をフォールバックに使う。
+const sentryRelease = process.env.VITE_SENTRY_RELEASE || process.env.VERCEL_GIT_COMMIT_SHA;
+// 3 つの認証情報が揃ったビルドだけアップロードする。揃っていなければ
+// プラグインを差し込まず、ソースマップも生成しない（ビルドは壊れない）。
+const uploadSourcemaps = Boolean(sentryAuthToken && sentryOrg && sentryProject);
+
 // More info at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon
 export default defineConfig({
-  plugins: [react()],
+  plugins: [
+    react(),
+    // sentryVitePlugin は最後に置く。アップロード後、公開しないよう
+    // .map ファイルは削除する。
+    ...(uploadSourcemaps
+      ? [
+          sentryVitePlugin({
+            authToken: sentryAuthToken,
+            org: sentryOrg,
+            project: sentryProject,
+            release: sentryRelease ? { name: sentryRelease } : undefined,
+            sourcemaps: { filesToDeleteAfterUpload: ['./dist/**/*.map'] },
+          }),
+        ]
+      : []),
+  ],
+  // ソースマップはアップロードする時だけ生成する。
+  build: {
+    sourcemap: uploadSourcemaps,
+  },
   test: {
     projects: [{
       // Plain unit tests (pure logic) running in Node — no browser required,


### PR DESCRIPTION
## 概要

エラートラッキング（Sentry）を導入します（#52）。

既存の #77 から **Sentry 関連の変更だけを取り出した** PR です。#77 はクローズせず残してありますので、本 PR がマージできそうなら差し替えてください。

## なぜ切り出したか

#77 は「Sentry 導入」というタイトルでしたが、実際には 17 ファイル・779 行あり、**予定リマインダー機能が同梱**されていました。

- `src/hooks/useEventReminders.ts`
- `src/components/Calendar/EventModal.tsx` の `reminderMinutes` UI
- `supabase/migrations/0009_event_reminder.sql`
- `src/components/Layout/MainLayout.tsx` のリマインダー通知トースト

リマインダーは #74 とあわせてスコープ外とする判断になったため、これらを除外しました。

### 🔴 あわせてマイグレーション番号の衝突も解消しています

#77 が追加する `0009_event_reminder.sql` は、main の `0009_harden_handle_new_user.sql` と**番号が重複**していました。

Supabase の履歴テーブルはバージョン番号を主キーにするため、このままマージすると **`0007` / `0008` で起きたのとまったく同じ「片方が履歴に記録されず `db push` が通らなくなる」問題**が再発するところでした。

本 PR は**マイグレーションを一切含みません**。リマインダーを将来復活させる場合は、その時点の最新番号（現在なら `0015`）を採番してください。

## 実装の要点

レビュー時に見ていただきたい設計判断です。

| 項目 | 挙動 |
|---|---|
| DSN 未設定時 | **Sentry を初期化しない**。ローカル開発・CI・テストに一切影響しない |
| `sendDefaultPii` | `false`。メール等は送らず、ユーザー識別は **ID のみ** |
| `tracesSampleRate` | `0`。エラー収集のみで、課金対象のパフォーマンス計測はしない |
| ソースマップ | `SENTRY_AUTH_TOKEN` / `SENTRY_ORG` / `SENTRY_PROJECT` が揃ったビルドでのみアップロードし、**アップロード後に `.map` を削除**（公開しない） |

`VITE_SENTRY_DSN` はブラウザに露出しますが、これは公開前提の値です（anon key と同様）。一方 `SENTRY_AUTH_TOKEN` は `VITE_` を付けていないため露出しません。

## 有効化の手順（マージ後）

このPRだけでは Sentry は動きません。DSN を設定して初めて有効になります。

1. Sentry でプロジェクトを作成し、DSN を取得
2. Vercel の Environment Variables に `VITE_SENTRY_DSN` を登録
3. 再デプロイ（`VITE_` 変数はビルド時に埋め込まれるため、登録だけでは反映されない）

## 確認

- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm test`（16 tests passed）
- [x] DSN 未設定の dev サーバーで、`ingest.sentry.io` への通信が発生しないことをネットワークログで確認
- [x] リマインダー関連コードの残骸が無いことを確認（`useEventReminders` / `reminderMinutes` / `event_reminder` で grep）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
