### PR TITLE
test(chat): RoomView の表示ロジックを純粋関数に切り出してテストする

### DIFF
--- a/src/components/Chat/RoomView.tsx
+++ b/src/components/Chat/RoomView.tsx
@@ -16,6 +16,7 @@ import { ArrowUpIcon, ArrowBackIcon } from '@chakra-ui/icons'
 import { supabase } from '../../lib/supabase'
 import { useTeamMembers } from '../../hooks/useTeamMembers'
 import { RoomMembersModal } from './RoomMembersModal'
+import { computeMessageFlags, formatDateLabel, formatTime } from './roomViewUtils'
 import type { Database } from '../../types/database'
 
 type MessageRow = Database['public']['Tables']['team_messages']['Row']
@@ -25,30 +26,6 @@ type Team = Database['public']['Tables']['teams']['Row']
 const CHAT_BG = '#8cabd8'
 const MY_BUBBLE = '#8de055'
 const SEND_GREEN = '#06c755'
-
-const WEEKDAYS = ['日', '月', '火', '水', '木', '金', '土']
-
-function isSameDay(a: string | null, b: string | null) {
-  if (!a || !b) return false
-  const da = new Date(a)
-  const db = new Date(b)
-  return (
-    da.getFullYear() === db.getFullYear() &&
-    da.getMonth() === db.getMonth() &&
-    da.getDate() === db.getDate()
-  )
-}
-
-function formatDateLabel(iso: string | null) {
-  if (!iso) return ''
-  const d = new Date(iso)
-  return `${d.getMonth() + 1}月${d.getDate()}日(${WEEKDAYS[d.getDay()]})`
-}
-
-function formatTime(iso: string | null) {
-  if (!iso) return ''
-  return new Date(iso).toLocaleTimeString('ja-JP', { hour: '2-digit', minute: '2-digit', hour12: false })
-}
 
 interface RoomViewProps {
   team: Team
@@ -76,6 +53,9 @@ export function RoomView({ team, currentUserId, onBack, onLeft }: RoomViewProps)
     () => new Map(memberState.members.map((m) => [m.userId, m.displayName])),
     [memberState.members],
   )
+
+  // 日付セパレータと連投グルーピングの判定（ロジックは roomViewUtils）。
+  const messageFlags = useMemo(() => computeMessageFlags(messages), [messages])
 
   const fetchMessages = useCallback(async (tid: string) => {
     setLoading(true)
@@ -172,10 +152,8 @@ export function RoomView({ team, currentUserId, onBack, onLeft }: RoomViewProps)
         ) : (
           <Box>
             {messages.map((m, i) => {
-              const prev = messages[i - 1]
               const mine = m.userId === currentUserId
-              const showDate = !prev || !isSameDay(prev.createdAt, m.createdAt)
-              const startGroup = showDate || !prev || prev.userId !== m.userId
+              const { showDate, startGroup } = messageFlags[i]
               const time = (
                 <Text fontSize="10px" color="blackAlpha.600" flexShrink={0} pb="2px">
                   {formatTime(m.createdAt)}

--- a/src/components/Chat/roomViewUtils.test.ts
+++ b/src/components/Chat/roomViewUtils.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'vitest'
+import {
+  isSameDay,
+  formatDateLabel,
+  formatTime,
+  computeMessageFlags,
+  type MessageLike,
+} from './roomViewUtils'
+
+// 日時はローカル時刻で組み立てる。isSameDay / formatDateLabel は閲覧者の
+// ローカルタイムゾーンで判定するため、こうしておくと実行環境の TZ に
+// 依らずアサーションが安定する（calendarUtils.test.ts と同じ方針）。
+function at(y: number, m: number, d: number, h = 12, min = 0) {
+  return new Date(y, m - 1, d, h, min).toISOString()
+}
+
+function msg(userId: string, createdAt: string | null): MessageLike {
+  return { userId, createdAt }
+}
+
+describe('isSameDay', () => {
+  it('同じ日なら true', () => {
+    expect(isSameDay(at(2026, 8, 11, 0, 0), at(2026, 8, 11, 23, 59))).toBe(true)
+  })
+
+  it('日を跨ぐと false（1分差でも）', () => {
+    expect(isSameDay(at(2026, 8, 11, 23, 59), at(2026, 8, 12, 0, 0))).toBe(false)
+  })
+
+  it('月をまたぐ同じ日付は false', () => {
+    expect(isSameDay(at(2026, 8, 11), at(2026, 9, 11))).toBe(false)
+  })
+
+  it('年をまたぐ同じ月日は false', () => {
+    expect(isSameDay(at(2025, 8, 11), at(2026, 8, 11))).toBe(false)
+  })
+
+  it('null が絡む場合は false', () => {
+    expect(isSameDay(null, at(2026, 8, 11))).toBe(false)
+    expect(isSameDay(at(2026, 8, 11), null)).toBe(false)
+    expect(isSameDay(null, null)).toBe(false)
+  })
+})
+
+describe('formatDateLabel', () => {
+  it('月日と曜日を出す', () => {
+    // 2026-08-11 は火曜日
+    expect(formatDateLabel(at(2026, 8, 11))).toBe('8月11日(火)')
+  })
+
+  it('1桁の月日をゼロ埋めしない', () => {
+    // 2026-01-05 は月曜日
+    expect(formatDateLabel(at(2026, 1, 5))).toBe('1月5日(月)')
+  })
+
+  it('null は空文字', () => {
+    expect(formatDateLabel(null)).toBe('')
+  })
+})
+
+describe('formatTime', () => {
+  it('24時間表記でゼロ埋めする', () => {
+    expect(formatTime(at(2026, 8, 11, 9, 5))).toBe('09:05')
+  })
+
+  it('午後を 24 時間表記で出す', () => {
+    expect(formatTime(at(2026, 8, 11, 21, 30))).toBe('21:30')
+  })
+
+  it('null は空文字', () => {
+    expect(formatTime(null)).toBe('')
+  })
+})
+
+describe('computeMessageFlags', () => {
+  it('空配列なら空配列', () => {
+    expect(computeMessageFlags([])).toEqual([])
+  })
+
+  it('先頭は必ず日付セパレータとグループ先頭になる', () => {
+    const flags = computeMessageFlags([msg('u1', at(2026, 8, 11, 10, 0))])
+    expect(flags).toEqual([{ showDate: true, startGroup: true }])
+  })
+
+  it('同じ人の連投はグループ先頭にしない', () => {
+    const flags = computeMessageFlags([
+      msg('u1', at(2026, 8, 11, 10, 0)),
+      msg('u1', at(2026, 8, 11, 10, 1)),
+      msg('u1', at(2026, 8, 11, 10, 2)),
+    ])
+    expect(flags.map((f) => f.startGroup)).toEqual([true, false, false])
+    expect(flags.map((f) => f.showDate)).toEqual([true, false, false])
+  })
+
+  it('話者が変わったらグループ先頭になる', () => {
+    const flags = computeMessageFlags([
+      msg('u1', at(2026, 8, 11, 10, 0)),
+      msg('u2', at(2026, 8, 11, 10, 1)),
+      msg('u1', at(2026, 8, 11, 10, 2)),
+    ])
+    expect(flags.map((f) => f.startGroup)).toEqual([true, true, true])
+    expect(flags.map((f) => f.showDate)).toEqual([true, false, false])
+  })
+
+  it('日が変わったらセパレータを出す', () => {
+    const flags = computeMessageFlags([
+      msg('u1', at(2026, 8, 11, 23, 59)),
+      msg('u2', at(2026, 8, 12, 0, 1)),
+    ])
+    expect(flags.map((f) => f.showDate)).toEqual([true, true])
+  })
+
+  it('日跨ぎで同じ人が続く場合もセパレータ直後はグループ先頭にする', () => {
+    // アバターと名前が出ないまま日付が変わると、誰の発言か分からなくなる
+    const flags = computeMessageFlags([
+      msg('u1', at(2026, 8, 11, 23, 59)),
+      msg('u1', at(2026, 8, 12, 0, 1)),
+    ])
+    expect(flags[1]).toEqual({ showDate: true, startGroup: true })
+  })
+
+  it('createdAt が null のメッセージでもセパレータ判定で落ちない', () => {
+    const flags = computeMessageFlags([msg('u1', null), msg('u1', null)])
+    // null 同士は同日と見なせないため、毎回セパレータ扱いになる
+    expect(flags.map((f) => f.showDate)).toEqual([true, true])
+    expect(flags).toHaveLength(2)
+  })
+
+  it('入力と同じ長さの配列を返す', () => {
+    const messages = Array.from({ length: 7 }, (_, i) =>
+      msg(i % 2 === 0 ? 'u1' : 'u2', at(2026, 8, 11, 10, i)),
+    )
+    expect(computeMessageFlags(messages)).toHaveLength(7)
+  })
+})

--- a/src/components/Chat/roomViewUtils.ts
+++ b/src/components/Chat/roomViewUtils.ts
@@ -1,0 +1,68 @@
+/**
+ * トークルーム（RoomView）の表示ロジック。
+ *
+ * 日付セパレータの位置や連投のまとめ方は、境界（日跨ぎ・話者交代・
+ * 先頭）で間違えやすい割に見た目からは気づきにくいので、描画から
+ * 切り離して純粋関数にしてある。
+ */
+
+const WEEKDAYS = ['日', '月', '火', '水', '木', '金', '土']
+
+/** 同じ暦日か（閲覧者のローカルタイムゾーンで判定）。 */
+export function isSameDay(a: string | null, b: string | null) {
+  if (!a || !b) return false
+  const da = new Date(a)
+  const db = new Date(b)
+  return (
+    da.getFullYear() === db.getFullYear() &&
+    da.getMonth() === db.getMonth() &&
+    da.getDate() === db.getDate()
+  )
+}
+
+/** 日付セパレータの見出し（例: 8月11日(火)）。 */
+export function formatDateLabel(iso: string | null) {
+  if (!iso) return ''
+  const d = new Date(iso)
+  return `${d.getMonth() + 1}月${d.getDate()}日(${WEEKDAYS[d.getDay()]})`
+}
+
+/** 吹き出し脇の時刻（24時間表記）。 */
+export function formatTime(iso: string | null) {
+  if (!iso) return ''
+  return new Date(iso).toLocaleTimeString('ja-JP', {
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  })
+}
+
+/** フラグ計算に必要な最小限のメッセージ形。 */
+export interface MessageLike {
+  userId: string
+  createdAt: string | null
+}
+
+export interface MessageFlags {
+  /** この行の前に日付セパレータを出すか。 */
+  showDate: boolean
+  /** 連投のかたまりの先頭か（アバターと名前を出す位置）。 */
+  startGroup: boolean
+}
+
+/**
+ * 各メッセージの表示フラグをまとめて計算する。
+ * messages は古い順に並んでいる前提。
+ *
+ * - 日付が変わったらセパレータを出す（先頭は必ず出す）
+ * - 話者が変わったか、日付が変わったらグループの先頭にする
+ *   （日跨ぎで同じ人が続く場合も、セパレータの直後は先頭扱いにする）
+ */
+export function computeMessageFlags(messages: MessageLike[]): MessageFlags[] {
+  return messages.map((m, i) => {
+    const prev = messages[i - 1]
+    const showDate = !prev || !isSameDay(prev.createdAt, m.createdAt)
+    const startGroup = showDate || prev.userId !== m.userId
+    return { showDate, startGroup }
+  })
+}


### PR DESCRIPTION
## 概要

トークルームの表示ロジックを純粋関数に切り出し、テストを付けました。**振る舞いは変えていません。**

現状テストは `calendarUtils.test.ts` の 16 件だけで、先日入れたトークルーム関連は全部ノーテストでした。そこを埋める第一弾です。

## なぜここから手を付けたか

日付セパレータの位置と連投のまとめ方は、**境界で間違えやすい割に、見た目からは気づきにくい**箇所です。

- 日が変わったのにセパレータが出ない
- 話者が変わったのにアバターが出ず、誰の発言か分からない
- 日跨ぎで同じ人が続くと、セパレータ直後に名前が出ない

どれも「動いてはいる」ので気づかれにくく、リファクタで壊れても検知できませんでした。

## 変更内容

`src/components/Chat/roomViewUtils.ts`（新規）に以下を移動しました。

| 関数 | 役割 |
|---|---|
| `isSameDay` | 同じ暦日か（閲覧者のローカル TZ で判定） |
| `formatDateLabel` | `8月11日(火)` |
| `formatTime` | `21:30`（24時間表記） |
| `computeMessageFlags` | 各メッセージの `showDate` / `startGroup` をまとめて計算 |

`RoomView` 側は `computeMessageFlags` を `useMemo` で呼ぶだけになり、`map` の中で前要素を参照する処理が消えました。

### ついでに直した冗長な分岐

```ts
// before
const startGroup = showDate || !prev || prev.userId !== m.userId
```

`!prev` のとき `showDate` は必ず `true` になるため、`!prev` の判定は**到達しません**。整理して `showDate || prev.userId !== m.userId` にしました。挙動は同じです。

## テスト（19件）

日跨ぎ・話者交代・連投・先頭・`createdAt` が `null` のケースを含みます。

日時は**ローカル時刻で組み立て**、実行環境のタイムゾーンに依存しないようにしました（`calendarUtils.test.ts` と同じ方針）。

### テストが実際に効くことを確認しました

書いたテストが素通りしないか、わざとロジックを壊して検証しています。

| 壊した箇所 | 結果 |
|---|---|
| 話者交代の判定を落とす | **1 件失敗** |
| 日付比較（`getDate`）を無効化 | **3 件失敗** |
| 復元 | 35 件全passs |

## 確認

- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm test`（35 passed / 既存16 + 新規19）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
