### PR TITLE
fix(security): teams/user_teams の RLS を本来の定義に戻す（#85, #86, #92）

### DIFF
--- a/src/components/Team/TeamsTab.tsx
+++ b/src/components/Team/TeamsTab.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useState } from 'react'
 import {
   Box,
   Flex,
@@ -22,6 +22,7 @@ import { CopyIcon, AddIcon } from '@chakra-ui/icons'
 import { supabase } from '../../lib/supabase'
 import { useAuth } from '../../hooks/useAuth'
 import { useMyTeamInvitations } from '../../hooks/useMyTeamInvitations'
+import { useTeamMembers } from '../../hooks/useTeamMembers'
 import { Button } from '../ui/Button'
 import { Card } from '../ui/Card'
 import type { Database } from '../../types/database'
@@ -29,12 +30,6 @@ import type { Database } from '../../types/database'
 type Team = Database['public']['Tables']['teams']['Row']
 type TeamInsert = Database['public']['Tables']['teams']['Insert']
 type UserTeamInsert = Database['public']['Tables']['user_teams']['Insert']
-
-type Member = {
-  userId: string
-  role: string
-  displayName: string
-}
 
 function InviteCode({ code }: { code: string }) {
   const { hasCopied, onCopy } = useClipboard(code)
@@ -77,43 +72,12 @@ function TeamCard({
   currentUserId: string | undefined
   onLeft: () => void
 }) {
-  const [members, setMembers] = useState<Member[]>([])
-  const [loading, setLoading] = useState(true)
+  // user_teams を直接引いてはいけない。user_teams_select（0001）は自分の行しか
+  // 返さないため、他のメンバーが見えない。SECURITY DEFINER の list_team_members
+  // 経由で取得する（0012）。
+  const { members, loading } = useTeamMembers(team.id)
   const [leaving, setLeaving] = useState(false)
   const toast = useToast()
-
-  const fetchMembers = useCallback(async () => {
-    setLoading(true)
-    try {
-      const { data: rows, error } = await supabase
-        .from('user_teams')
-        .select('userId, role')
-        .eq('teamId', team.id)
-      if (error || !rows) {
-        setMembers([])
-        return
-      }
-      const ids = rows.map((r) => r.userId)
-      const { data: users } = await supabase
-        .from('users')
-        .select('id, displayName')
-        .in('id', ids)
-      const nameById = new Map((users ?? []).map((u) => [u.id, u.displayName]))
-      setMembers(
-        rows.map((r) => ({
-          userId: r.userId,
-          role: r.role,
-          displayName: nameById.get(r.userId) ?? '不明なユーザー',
-        })),
-      )
-    } finally {
-      setLoading(false)
-    }
-  }, [team.id])
-
-  useEffect(() => {
-    fetchMembers()
-  }, [fetchMembers])
 
   const myRole = members.find((m) => m.userId === currentUserId)?.role
 

--- a/supabase/migrations/0016_restore_team_rls_policies.sql
+++ b/supabase/migrations/0016_restore_team_rls_policies.sql
@@ -1,0 +1,86 @@
+-- ============================================================
+-- 0016_restore_team_rls_policies.sql
+-- teams / user_teams の SELECT ポリシーを本来の定義に戻す（セキュリティ修正）
+--
+-- 経緯:
+--   本番の teams_select / user_teams_select が、動作確認のために
+--   手作業で USING (true) に書き換えられ、そのまま戻されていなかった。
+--   ポリシーの対象ロールは public（anon を含む）なので、
+--   ログイン不要で以下がすべて読み出せる状態だった:
+--     - 全ユーザーのメールアドレス・電話番号・生年月日（users）
+--     - 全チームの invitationalCode（teams）
+--     - 誰がどのチームに所属しているか（user_teams）
+--   招待コードが読めるということは、誰でも任意のチームに参加でき、
+--   そのメンバーの位置情報と予定が見えるということでもある。
+--
+-- 順序の注意:
+--   TeamsTab のメンバー一覧が user_teams を直接引いていたため、
+--   ポリシーを厳しくすると「メンバーが自分1人」になってしまう。
+--   本マイグレーションと同じコミットで list_team_members RPC 経由に
+--   置き換えてある。フロントエンドを先に直さないと画面が壊れる。
+--
+-- 冪等性:
+--   ALTER POLICY はポリシーが無いと失敗するため、
+--   DROP POLICY IF EXISTS + CREATE POLICY で書き直す。
+-- ============================================================
+
+
+-- ============================================================
+-- teams: 自分が所属するチームのみ SELECT 可
+-- ============================================================
+
+DROP POLICY IF EXISTS "teams_select" ON teams;
+
+CREATE POLICY "teams_select" ON teams
+  FOR SELECT USING (
+    id IN (
+      SELECT "teamId" FROM user_teams WHERE "userId" = auth.uid()
+    )
+  );
+
+-- 参加前のチームを invitationalCode で探す必要があるが、それは
+-- join_team_by_code（SECURITY DEFINER・0015）が担当する。
+-- クライアントから teams を直接検索する経路は塞いだままにする。
+
+
+-- ============================================================
+-- user_teams: 自分の所属行のみ SELECT 可
+-- ============================================================
+
+DROP POLICY IF EXISTS "user_teams_select" ON user_teams;
+
+CREATE POLICY "user_teams_select" ON user_teams
+  FOR SELECT USING ("userId" = auth.uid());
+
+-- チームのメンバー一覧は list_team_members（SECURITY DEFINER・0012）で取得する。
+
+
+-- ============================================================
+-- teams への INSERT を認証済みユーザーに限定する
+--
+-- 0001 の teams_insert は WITH CHECK (true) で、anon を含む誰でも
+-- 行を作成できた（実際に匿名で作成できることを確認済み）。
+-- teams には DELETE ポリシーが無いため「作れるが消せない」構造になり、
+-- スパム登録・孤児チームの量産・invitationalCode の枯渇を許していた。
+--
+-- なお本来はチーム作成自体を SECURITY DEFINER の RPC に集約し、
+-- teams への直接 INSERT を塞ぐのが望ましい（作成と user_teams への
+-- admin 登録を1トランザクションにできるため）。それは別 issue とし、
+-- ここでは匿名による作成だけを止める。
+-- ============================================================
+
+DROP POLICY IF EXISTS "teams_insert" ON teams;
+
+CREATE POLICY "teams_insert" ON teams
+  FOR INSERT WITH CHECK (auth.uid() IS NOT NULL);
+
+
+-- ============================================================
+-- NOTE: users_select は本マイグレーションでは変更しない。
+--
+-- users_select は 0001 の時点から USING (true) で、匿名を含む全員に
+-- 全行・全カラムを開放している。これは「書き換えられた」ものではなく
+-- 当初からの定義であり、フレンド検索がここに依存している。
+-- 絞るにはメールアドレス完全一致で最小限のカラムだけ返す RPC を
+-- 用意するなど、機能面の設計変更を伴うため別途対応する。
+-- ============================================================

--- a/supabase/migrations/0017_restore_user_teams_write_policies.sql
+++ b/supabase/migrations/0017_restore_user_teams_write_policies.sql
@@ -1,0 +1,51 @@
+-- ============================================================
+-- 0017_restore_user_teams_write_policies.sql
+-- user_teams の書き込みポリシーを本来の定義に戻す（セキュリティ修正）
+--
+-- 経緯:
+--   0016 で SELECT 系を戻したあと、user_teams_insert も
+--   WITH CHECK (true) に書き換えられていることが判明した。
+--   0016 と同じく、動作確認のために緩めて戻し忘れたもの。
+--
+-- 何が起きるか:
+--   対象ロールが public（anon を含む）かつ WITH CHECK (true) なので、
+--   ログインしていなくても任意の userId / teamId の組で行を作れる。
+--   実在する ID を使えば、任意のユーザーを任意のチームに参加させられる。
+--
+--   これは 0012 で入れた「チームへの参加は必ず本人の同意を要件とする」
+--   という設計を根本から迂回する。招待 → 承諾のフローを整えても、
+--   テーブルを直接叩けば同意なしに他人を放り込めてしまう。
+--   参加させられた相手の位置情報と予定が、そのチームから見える。
+--
+-- 正規の参加経路はいずれも SECURITY DEFINER の RPC で、本ポリシーの
+-- 影響を受けない:
+--   - join_team_by_code   … 招待コードによる参加（0015）
+--   - accept_team_invitation … 招待の承諾（0012）
+--   - チーム作成時の admin 登録 … クライアントからの直接 INSERT だが
+--     自分の行なので "userId" = auth.uid() を満たす
+-- ============================================================
+
+
+-- ============================================================
+-- user_teams: 自分の行のみ作成できる
+-- ============================================================
+
+DROP POLICY IF EXISTS "user_teams_insert" ON user_teams;
+
+CREATE POLICY "user_teams_insert" ON user_teams
+  FOR INSERT WITH CHECK ("userId" = auth.uid());
+
+
+-- ============================================================
+-- user_teams: 自分の行のみ削除できる（退出）
+--
+-- 0001 の定義と同じだが、こちらも緩められていないか確認できて
+-- いないため、あわせて明示的に貼り直しておく。
+-- 他メンバーの追放は remove_team_member（SECURITY DEFINER・0012）が
+-- 担当し、teams."removalPolicy" に従って権限を判定する。
+-- ============================================================
+
+DROP POLICY IF EXISTS "user_teams_delete" ON user_teams;
+
+CREATE POLICY "user_teams_delete" ON user_teams
+  FOR DELETE USING ("userId" = auth.uid());


### PR DESCRIPTION
## 概要

匿名で個人情報とチームの招待コードが読み出せる状態を修正します。**#85 / #86 / #92 をまとめて解決します。**

> ⚠️ **このPRは #84 を含みます**（ブランチを `fix/join-team-by-code` から切っているため）。#84 を先にマージすると、このPRの差分は `0016` と `TeamsTab.tsx` だけになります。

## 何が起きていたか

本番の `teams_select` / `user_teams_select` が、**動作確認のために手作業で `USING (true)` に書き換えられ、そのまま戻されていませんでした。**

```sql
alter policy "teams_select"      on "public"."teams"      to public using ( true );
alter policy "user_teams_select" on "public"."user_teams" to public using ( true );
```

`to public` は anon を含む全ロールが対象です。そのため **ログイン不要で** 以下が読み出せました。

| 読み出せたもの | 件数 |
|---|---|
| 全ユーザーのメールアドレス・電話番号・生年月日 | 21件 |
| 全チームの `invitationalCode` | 13件 |
| 誰がどのチームに所属しているか | 19件 |

**招待コードが読める＝誰でも任意のチームに参加でき、そのメンバーの位置情報と予定が見られる**ということでもあります。位置情報アプリとして最も避けたい状態でした。

## 修正には順序の依存関係があります

`TeamsTab` のメンバー一覧が `user_teams` を直接引いていたため、**ポリシーを厳しくすると「メンバーが自分1人」になってしまいます**（#86）。

おそらく**この症状を回避するためにポリシーが緩められた**のだと思われます。そのため両方を同じコミットで修正しています。

1. `TeamCard` を `useTeamMembers`（`list_team_members` RPC）経由に変更 — RPC は `SECURITY DEFINER` なので RLS を厳しくしても動く
2. そのうえでポリシーを `0001` の定義に戻す

## 変更内容

**`0016_restore_team_rls_policies.sql`（新規）**

- `teams_select` — 自分が所属するチームのみ
- `user_teams_select` — 自分の所属行のみ
- `teams_insert` — **認証済みユーザーに限定**（#92）。`0001` の `WITH CHECK (true)` は anon でも作成でき、`teams` に DELETE ポリシーが無いため「作れるが消せない」構造でした

`ALTER POLICY` はポリシーが存在しないと失敗するため、`DROP POLICY IF EXISTS` + `CREATE POLICY` で冪等にしています。

**`TeamsTab.tsx`**

`TeamCard` の `fetchMembers`（`user_teams` + `users` の2クエリ）を削除し、`useTeamMembers` フックに置き換えました。ローカル state と `useEffect` が不要になり、正味 30 行ほど減っています。

## `users_select` は変更していません

`users_select` は `0001` の時点から `USING (true)` で、**書き換えられたものではありません**。フレンド検索がこれに依存しているため、絞るにはメールアドレス完全一致の RPC を用意するなど機能面の設計変更が要ります。**#85 に残タスクとして残します。**

そのため、このPR適用後も **`users` の21件は匿名で読めたままです**。

## 適用済み・検証済み

`0016` は**本番に適用済み**です。修正前後を実測しました。

| 検証項目 | 修正前 | 修正後 |
|---|---|---|
| 匿名で `teams` を読む | 13件 | **0件** ✅ |
| 匿名で `user_teams` を読む | 19件 | **0件** ✅ |
| 匿名で `teams` に INSERT | **成功** | **`42501` RLS 拒否** ✅ |
| 匿名で `users` を読む | 21件 | 21件（未対応・上記の通り） |

- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm test`（54 passed）

⚠️ **チームタブのメンバー一覧は実画面で未確認です。** ログインが必要なため、**チームタブでメンバーが全員表示されるか**の確認をお願いします。ここが壊れていると、今回の修正で見え方が変わる唯一の箇所になります。

## 関連

- Closes #86
- Closes #92
- Closes #91（`user_teams` が塞がったため `is_team_member` の REVOKE が本来の意味を持つようになった）
- #85 は `users_select` の対応が残るため**オープンのまま**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
