### PR TITLE
fix(security): users の連絡先を他人から見えなくする（#85）

### DIFF
--- a/src/components/Chat/RoomMembersModal.tsx
+++ b/src/components/Chat/RoomMembersModal.tsx
@@ -28,6 +28,7 @@ import {
 } from '@chakra-ui/react'
 import { CopyIcon, CloseIcon, AddIcon } from '@chakra-ui/icons'
 import { supabase } from '../../lib/supabase'
+import { fetchPublicProfiles } from '../../lib/profiles'
 import type { useTeamMembers } from '../../hooks/useTeamMembers'
 import { Button } from '../ui/Button'
 
@@ -96,8 +97,9 @@ export function RoomMembersModal({
       .eq('userId', currentUserId)
     const ids = (rows ?? []).map((r) => r.friendId)
     if (ids.length === 0) return setFriends([])
-    const { data: users } = await supabase.from('users').select('id, displayName').in('id', ids)
-    setFriends((users ?? []).map((u) => ({ id: u.id, displayName: u.displayName })))
+    // 他人の表示名は公開情報の RPC から引く（0018）。
+    const names = await fetchPublicProfiles(ids)
+    setFriends(ids.map((id) => ({ id, displayName: names.get(id) ?? '不明なユーザー' })))
   }, [currentUserId])
 
   useEffect(() => {

--- a/src/components/Friends/FriendsTab.tsx
+++ b/src/components/Friends/FriendsTab.tsx
@@ -15,10 +15,13 @@ import {
 } from '@chakra-ui/react'
 import { supabase } from '../../lib/supabase'
 import { useAuth } from '../../hooks/useAuth'
+import { fetchPublicProfiles, searchUsers } from '../../lib/profiles'
 import { Button } from '../ui/Button'
 import { Card } from '../ui/Card'
 
-type Person = { id: string; displayName: string; email: string }
+// 他人について保持してよいのは公開情報（表示名）だけ。
+// メールアドレスはクライアントへ渡さない（0018）。
+type Person = { id: string; displayName: string }
 type RequestItem = { requestId: string; person: Person }
 
 export default function FriendsTab() {
@@ -62,15 +65,13 @@ export default function FriendsTab() {
           ...outgoingRaw.map((r) => r.addresseeId),
         ]),
       )
-      const people = new Map<string, Person>()
-      if (ids.length > 0) {
-        const { data: users } = await supabase
-          .from('users')
-          .select('id, displayName, email')
-          .in('id', ids)
-        for (const u of users ?? []) people.set(u.id, u)
-      }
-      const get = (id: string): Person => people.get(id) ?? { id, displayName: '不明なユーザー', email: '' }
+      // users を直接引かない。他人の行は見えず、そもそも表示名以外を
+      // クライアントへ渡さないため RPC 経由にしている（0018）。
+      const names = await fetchPublicProfiles(ids)
+      const get = (id: string): Person => ({
+        id,
+        displayName: names.get(id) ?? '不明なユーザー',
+      })
 
       setFriends(friendIds.map(get))
       setIncoming(incomingRaw.map((r) => ({ requestId: r.id, person: get(r.requesterId) })))
@@ -91,19 +92,15 @@ export default function FriendsTab() {
     }
     setSearching(true)
     try {
-      const q = `%${query.trim()}%`
-      const { data } = await supabase
-        .from('users')
-        .select('id, displayName, email')
-        .or(`displayName.ilike.${q},email.ilike.${q}`)
-        .neq('id', user.id)
-        .limit(10)
+      // 表示名は部分一致、メールアドレスは完全一致（サーバ側で制限）。
+      // 検索結果に連絡先は含まれない（0018）。
+      const found = await searchUsers(query)
       const excluded = new Set([
         ...friends.map((f) => f.id),
         ...incoming.map((i) => i.person.id),
         ...outgoing.map((o) => o.person.id),
       ])
-      setResults((data ?? []).filter((u) => !excluded.has(u.id)))
+      setResults(found.filter((u) => !excluded.has(u.id)))
     } finally {
       setSearching(false)
     }
@@ -186,11 +183,9 @@ export default function FriendsTab() {
             <Text fontSize="sm" fontWeight="600" color="gray.800" noOfLines={1}>
               {person.displayName}
             </Text>
-            {person.email && (
-              <Text fontSize="xs" color="gray.500" noOfLines={1}>
-                {person.email}
-              </Text>
-            )}
+            {/* メールアドレスは表示しない。他人の連絡先はクライアントへ
+                渡さない方針のため（0018）。同名の相手を見分ける手段は
+                @ユーザー名の導入で別途検討する。 */}
           </Box>
         </HStack>
         <HStack spacing={2} flexShrink={0}>

--- a/src/components/Map/MapTab.tsx
+++ b/src/components/Map/MapTab.tsx
@@ -23,6 +23,7 @@ import {
   FormLabel,
 } from '@chakra-ui/react'
 import { supabase } from '../../lib/supabase'
+import { fetchPublicProfiles } from '../../lib/profiles'
 import { useAuth } from '../../hooks/useAuth'
 import { useRealtimeLocations } from '../../hooks/useRealtime'
 import { MapPin } from './MapPin'
@@ -161,20 +162,15 @@ export default function MapTab() {
       setMemberNames(new Map())
       return
     }
-    const { data: rows } = await supabase
-      .from('user_teams')
-      .select('userId')
-      .in('teamId', teamIds)
-    const ids = Array.from(new Set((rows ?? []).map((r) => r.userId)))
-    if (ids.length === 0) {
+    // user_teams を直接引かない。user_teams_select は自分の行しか返さないため
+    // チームメイトを集められない。所属チームをまたいだ一覧を RPC で取る（0018）。
+    const { data, error } = await supabase.rpc('list_my_teammates')
+    if (error) {
+      console.error('list_my_teammates error', error)
       setMemberNames(new Map())
       return
     }
-    const { data: users } = await supabase
-      .from('users')
-      .select('id, displayName')
-      .in('id', ids)
-    setMemberNames(new Map((users ?? []).map((u) => [u.id, u.displayName])))
+    setMemberNames(new Map((data ?? []).map((u) => [u.id, u.display_name])))
   }, [teamIds])
 
   const fetchFriends = useCallback(async () => {
@@ -191,11 +187,8 @@ export default function MapTab() {
       setFriendNames(new Map())
       return
     }
-    const { data: users } = await supabase
-      .from('users')
-      .select('id, displayName')
-      .in('id', ids)
-    setFriendNames(new Map((users ?? []).map((u) => [u.id, u.displayName])))
+    // 他人の表示名は公開情報の RPC から引く（0018）。
+    setFriendNames(await fetchPublicProfiles(ids))
   }, [user])
 
   // displayName for anyone we're allowed to see (teammates + friends).

--- a/src/components/Team/TeamsTab.tsx
+++ b/src/components/Team/TeamsTab.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useState } from 'react'
 import {
   Box,
   Flex,
@@ -22,6 +22,7 @@ import { CopyIcon, AddIcon } from '@chakra-ui/icons'
 import { supabase } from '../../lib/supabase'
 import { useAuth } from '../../hooks/useAuth'
 import { useMyTeamInvitations } from '../../hooks/useMyTeamInvitations'
+import { useTeamMembers } from '../../hooks/useTeamMembers'
 import { Button } from '../ui/Button'
 import { Card } from '../ui/Card'
 import type { Database } from '../../types/database'
@@ -29,12 +30,6 @@ import type { Database } from '../../types/database'
 type Team = Database['public']['Tables']['teams']['Row']
 type TeamInsert = Database['public']['Tables']['teams']['Insert']
 type UserTeamInsert = Database['public']['Tables']['user_teams']['Insert']
-
-type Member = {
-  userId: string
-  role: string
-  displayName: string
-}
 
 function InviteCode({ code }: { code: string }) {
   const { hasCopied, onCopy } = useClipboard(code)
@@ -77,43 +72,12 @@ function TeamCard({
   currentUserId: string | undefined
   onLeft: () => void
 }) {
-  const [members, setMembers] = useState<Member[]>([])
-  const [loading, setLoading] = useState(true)
+  // user_teams を直接引いてはいけない。user_teams_select（0001）は自分の行しか
+  // 返さないため、他のメンバーが見えない。SECURITY DEFINER の list_team_members
+  // 経由で取得する（0012）。
+  const { members, loading } = useTeamMembers(team.id)
   const [leaving, setLeaving] = useState(false)
   const toast = useToast()
-
-  const fetchMembers = useCallback(async () => {
-    setLoading(true)
-    try {
-      const { data: rows, error } = await supabase
-        .from('user_teams')
-        .select('userId, role')
-        .eq('teamId', team.id)
-      if (error || !rows) {
-        setMembers([])
-        return
-      }
-      const ids = rows.map((r) => r.userId)
-      const { data: users } = await supabase
-        .from('users')
-        .select('id, displayName')
-        .in('id', ids)
-      const nameById = new Map((users ?? []).map((u) => [u.id, u.displayName]))
-      setMembers(
-        rows.map((r) => ({
-          userId: r.userId,
-          role: r.role,
-          displayName: nameById.get(r.userId) ?? '不明なユーザー',
-        })),
-      )
-    } finally {
-      setLoading(false)
-    }
-  }, [team.id])
-
-  useEffect(() => {
-    fetchMembers()
-  }, [fetchMembers])
 
   const myRole = members.find((m) => m.userId === currentUserId)?.role
 

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -1,9 +1,11 @@
 import { useCallback, useEffect, useState } from 'react'
 import { supabase } from '../lib/supabase'
+import { fetchPublicProfiles } from '../lib/profiles'
 
 export interface FriendRequestNotification {
   requestId: string
-  requester: { id: string; displayName: string; email: string }
+  // 他人について保持してよいのは公開情報（表示名）だけ（0018）。
+  requester: { id: string; displayName: string }
   createdAt: string | null
 }
 
@@ -37,21 +39,16 @@ export function useNotifications(userId: string | undefined) {
         setFriendRequests([])
         return
       }
-      const ids = rows.map((r) => r.requesterId)
-      const { data: users } = await supabase
-        .from('users')
-        .select('id, displayName, email')
-        .in('id', ids)
-      const byId = new Map((users ?? []).map((u) => [u.id, u]))
+      // 申請者の表示名は公開情報の RPC から引く（0018）。
+      const names = await fetchPublicProfiles(rows.map((r) => r.requesterId))
 
       setFriendRequests(
         rows.map((r) => ({
           requestId: r.id,
           createdAt: r.createdAt,
-          requester: byId.get(r.requesterId) ?? {
+          requester: {
             id: r.requesterId,
-            displayName: '不明なユーザー',
-            email: '',
+            displayName: names.get(r.requesterId) ?? '不明なユーザー',
           },
         })),
       )

--- a/src/lib/profiles.ts
+++ b/src/lib/profiles.ts
@@ -1,0 +1,41 @@
+import { supabase } from './supabase'
+
+/**
+ * 他人の表示名を引くための共通処理。
+ *
+ * users テーブルは「自分の行のみ」しか直接 SELECT できない（0018）。
+ * メールアドレス・電話番号・生年月日を他人に見せないためで、
+ * 他人の表示名は公開情報だけを返す RPC 経由で取得する。
+ */
+
+/** 指定した ID の表示名を引く。userId -> displayName のマップを返す。 */
+export async function fetchPublicProfiles(ids: string[]): Promise<Map<string, string>> {
+  const unique = Array.from(new Set(ids)).filter(Boolean)
+  if (unique.length === 0) return new Map()
+
+  const { data, error } = await supabase.rpc('get_public_profiles', { p_ids: unique })
+  if (error) {
+    console.error('get_public_profiles error', error)
+    return new Map()
+  }
+  return new Map((data ?? []).map((r) => [r.id, r.display_name]))
+}
+
+export interface PublicProfile {
+  id: string
+  displayName: string
+}
+
+/**
+ * 表示名の部分一致、またはメールアドレスの完全一致でユーザーを探す。
+ * メールを部分一致にすると総当たりでアドレスを探れてしまうため、
+ * サーバ側（search_users）で完全一致に限定している。
+ */
+export async function searchUsers(query: string): Promise<PublicProfile[]> {
+  const { data, error } = await supabase.rpc('search_users', { p_query: query })
+  if (error) {
+    console.error('search_users error', error)
+    return []
+  }
+  return (data ?? []).map((r) => ({ id: r.id, displayName: r.display_name }))
+}

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -277,6 +277,18 @@ export type Database = {
         Args: { code: string }
         Returns: string
       }
+      get_public_profiles: {
+        Args: { p_ids: string[] }
+        Returns: { id: string; display_name: string }[]
+      }
+      search_users: {
+        Args: { p_query: string }
+        Returns: { id: string; display_name: string }[]
+      }
+      list_my_teammates: {
+        Args: Record<string, never>
+        Returns: { id: string; display_name: string }[]
+      }
       list_team_members: {
         Args: { p_team_id: string }
         Returns: {

--- a/supabase/migrations/0016_restore_team_rls_policies.sql
+++ b/supabase/migrations/0016_restore_team_rls_policies.sql
@@ -1,0 +1,86 @@
+-- ============================================================
+-- 0016_restore_team_rls_policies.sql
+-- teams / user_teams の SELECT ポリシーを本来の定義に戻す（セキュリティ修正）
+--
+-- 経緯:
+--   本番の teams_select / user_teams_select が、動作確認のために
+--   手作業で USING (true) に書き換えられ、そのまま戻されていなかった。
+--   ポリシーの対象ロールは public（anon を含む）なので、
+--   ログイン不要で以下がすべて読み出せる状態だった:
+--     - 全ユーザーのメールアドレス・電話番号・生年月日（users）
+--     - 全チームの invitationalCode（teams）
+--     - 誰がどのチームに所属しているか（user_teams）
+--   招待コードが読めるということは、誰でも任意のチームに参加でき、
+--   そのメンバーの位置情報と予定が見えるということでもある。
+--
+-- 順序の注意:
+--   TeamsTab のメンバー一覧が user_teams を直接引いていたため、
+--   ポリシーを厳しくすると「メンバーが自分1人」になってしまう。
+--   本マイグレーションと同じコミットで list_team_members RPC 経由に
+--   置き換えてある。フロントエンドを先に直さないと画面が壊れる。
+--
+-- 冪等性:
+--   ALTER POLICY はポリシーが無いと失敗するため、
+--   DROP POLICY IF EXISTS + CREATE POLICY で書き直す。
+-- ============================================================
+
+
+-- ============================================================
+-- teams: 自分が所属するチームのみ SELECT 可
+-- ============================================================
+
+DROP POLICY IF EXISTS "teams_select" ON teams;
+
+CREATE POLICY "teams_select" ON teams
+  FOR SELECT USING (
+    id IN (
+      SELECT "teamId" FROM user_teams WHERE "userId" = auth.uid()
+    )
+  );
+
+-- 参加前のチームを invitationalCode で探す必要があるが、それは
+-- join_team_by_code（SECURITY DEFINER・0015）が担当する。
+-- クライアントから teams を直接検索する経路は塞いだままにする。
+
+
+-- ============================================================
+-- user_teams: 自分の所属行のみ SELECT 可
+-- ============================================================
+
+DROP POLICY IF EXISTS "user_teams_select" ON user_teams;
+
+CREATE POLICY "user_teams_select" ON user_teams
+  FOR SELECT USING ("userId" = auth.uid());
+
+-- チームのメンバー一覧は list_team_members（SECURITY DEFINER・0012）で取得する。
+
+
+-- ============================================================
+-- teams への INSERT を認証済みユーザーに限定する
+--
+-- 0001 の teams_insert は WITH CHECK (true) で、anon を含む誰でも
+-- 行を作成できた（実際に匿名で作成できることを確認済み）。
+-- teams には DELETE ポリシーが無いため「作れるが消せない」構造になり、
+-- スパム登録・孤児チームの量産・invitationalCode の枯渇を許していた。
+--
+-- なお本来はチーム作成自体を SECURITY DEFINER の RPC に集約し、
+-- teams への直接 INSERT を塞ぐのが望ましい（作成と user_teams への
+-- admin 登録を1トランザクションにできるため）。それは別 issue とし、
+-- ここでは匿名による作成だけを止める。
+-- ============================================================
+
+DROP POLICY IF EXISTS "teams_insert" ON teams;
+
+CREATE POLICY "teams_insert" ON teams
+  FOR INSERT WITH CHECK (auth.uid() IS NOT NULL);
+
+
+-- ============================================================
+-- NOTE: users_select は本マイグレーションでは変更しない。
+--
+-- users_select は 0001 の時点から USING (true) で、匿名を含む全員に
+-- 全行・全カラムを開放している。これは「書き換えられた」ものではなく
+-- 当初からの定義であり、フレンド検索がここに依存している。
+-- 絞るにはメールアドレス完全一致で最小限のカラムだけ返す RPC を
+-- 用意するなど、機能面の設計変更を伴うため別途対応する。
+-- ============================================================

--- a/supabase/migrations/0017_restore_user_teams_write_policies.sql
+++ b/supabase/migrations/0017_restore_user_teams_write_policies.sql
@@ -1,0 +1,51 @@
+-- ============================================================
+-- 0017_restore_user_teams_write_policies.sql
+-- user_teams の書き込みポリシーを本来の定義に戻す（セキュリティ修正）
+--
+-- 経緯:
+--   0016 で SELECT 系を戻したあと、user_teams_insert も
+--   WITH CHECK (true) に書き換えられていることが判明した。
+--   0016 と同じく、動作確認のために緩めて戻し忘れたもの。
+--
+-- 何が起きるか:
+--   対象ロールが public（anon を含む）かつ WITH CHECK (true) なので、
+--   ログインしていなくても任意の userId / teamId の組で行を作れる。
+--   実在する ID を使えば、任意のユーザーを任意のチームに参加させられる。
+--
+--   これは 0012 で入れた「チームへの参加は必ず本人の同意を要件とする」
+--   という設計を根本から迂回する。招待 → 承諾のフローを整えても、
+--   テーブルを直接叩けば同意なしに他人を放り込めてしまう。
+--   参加させられた相手の位置情報と予定が、そのチームから見える。
+--
+-- 正規の参加経路はいずれも SECURITY DEFINER の RPC で、本ポリシーの
+-- 影響を受けない:
+--   - join_team_by_code   … 招待コードによる参加（0015）
+--   - accept_team_invitation … 招待の承諾（0012）
+--   - チーム作成時の admin 登録 … クライアントからの直接 INSERT だが
+--     自分の行なので "userId" = auth.uid() を満たす
+-- ============================================================
+
+
+-- ============================================================
+-- user_teams: 自分の行のみ作成できる
+-- ============================================================
+
+DROP POLICY IF EXISTS "user_teams_insert" ON user_teams;
+
+CREATE POLICY "user_teams_insert" ON user_teams
+  FOR INSERT WITH CHECK ("userId" = auth.uid());
+
+
+-- ============================================================
+-- user_teams: 自分の行のみ削除できる（退出）
+--
+-- 0001 の定義と同じだが、こちらも緩められていないか確認できて
+-- いないため、あわせて明示的に貼り直しておく。
+-- 他メンバーの追放は remove_team_member（SECURITY DEFINER・0012）が
+-- 担当し、teams."removalPolicy" に従って権限を判定する。
+-- ============================================================
+
+DROP POLICY IF EXISTS "user_teams_delete" ON user_teams;
+
+CREATE POLICY "user_teams_delete" ON user_teams
+  FOR DELETE USING ("userId" = auth.uid());

--- a/supabase/migrations/0018_hide_user_contact_info.sql
+++ b/supabase/migrations/0018_hide_user_contact_info.sql
@@ -1,0 +1,145 @@
+-- ============================================================
+-- 0018_hide_user_contact_info.sql
+-- users の連絡先を他人から見えなくする（セキュリティ修正）
+--
+-- 問題:
+--   users_select は 0001 の時点から USING (true) で、匿名を含む誰でも
+--   全行・全カラムを読めた。実際に本番から全ユーザーのメールアドレスを
+--   取得できることを確認している。
+--
+-- 方針（Instagram / X と同じ考え方）:
+--   検索できること自体は問題ではない。公開してよい情報（表示名）と、
+--   絶対に出さない情報（メール・電話・生年月日）を分けるのが本質。
+--   あちらも表示名やユーザー名は部分一致で誰でも探せるが、
+--   メールアドレスは決して他人に返さない。
+--
+--   Postgres の RLS は行単位で列を制御できないため、
+--     - テーブルへの直接 SELECT は「自分の行のみ」に絞る
+--     - 公開情報だけを返す RPC を用意する
+--   という形にする。これにより検索の使い勝手は変えずに漏洩だけ止まる。
+--
+-- 注意:
+--   表示名は重複を許すため、同名ユーザーの見分けが付かなくなる。
+--   Instagram / X の @ユーザー名にあたる一意の識別子は現状無い。
+--   導入は別 issue とし、ここでは漏洩を止めることを優先する。
+-- ============================================================
+
+
+-- ============================================================
+-- users: 自分の行のみ直接 SELECT できる
+-- ============================================================
+
+DROP POLICY IF EXISTS "users_select" ON users;
+
+CREATE POLICY "users_select" ON users
+  FOR SELECT USING (id = auth.uid());
+
+-- 他人の表示名は下の RPC 経由でのみ取得する。
+
+
+-- ============================================================
+-- 公開プロフィールの取得（ID 指定）
+--
+-- フレンド一覧・地図のピン・トークルームの招待候補など、
+-- 「関係のある相手の名前を出す」用途で使う。
+-- 返すのは id と表示名だけで、メール等は一切含まない。
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.get_public_profiles(p_ids uuid[])
+RETURNS TABLE (id uuid, display_name text)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+STABLE
+AS $$
+  SELECT u.id, u."displayName"
+  FROM users u
+  WHERE u.id = ANY(p_ids)
+    AND auth.uid() IS NOT NULL;
+$$;
+
+
+-- ============================================================
+-- ユーザー検索（表示名の部分一致）
+--
+-- 従来のフロントエンドは users を直接 ilike で引いていたが、
+-- その結果にメールアドレスが含まれていた。表示名だけを返すことで
+-- 検索体験を維持したまま連絡先の漏洩を止める。
+--
+-- メールアドレスでの検索も残す。ただし部分一致だと総当たりで
+-- アドレスを探れてしまうため、完全一致のみとする。
+-- 「相手のメールを知っている人が追加する」用途は満たせる。
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.search_users(p_query text)
+RETURNS TABLE (id uuid, display_name text)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+STABLE
+AS $$
+DECLARE
+  v_query text := btrim(p_query);
+BEGIN
+  IF auth.uid() IS NULL THEN
+    RAISE EXCEPTION 'not authenticated';
+  END IF;
+
+  -- 短すぎるクエリは名簿の総なめに近くなるので弾く。
+  IF length(v_query) < 2 THEN
+    RETURN;
+  END IF;
+
+  RETURN QUERY
+    SELECT u.id, u."displayName"
+    FROM users u
+    WHERE u.id <> auth.uid()
+      AND (
+        u."displayName" ILIKE '%' || v_query || '%'
+        OR lower(u.email) = lower(v_query)   -- メールは完全一致のみ
+      )
+    ORDER BY u."displayName"
+    LIMIT 20;
+END;
+$$;
+
+
+-- ============================================================
+-- 自分と同じチームに属する全ユーザー（地図のピン表示用）
+--
+-- MapTab は user_teams を .in('teamId', teamIds) で直接引いて
+-- チームメイトの id を集めていたが、user_teams_select（0017 で
+-- 本来の定義に戻した）は自分の行しか返さないため機能しない。
+-- 地図は表示名の有無でピンを出し分けているので、これが欠けると
+-- フレンドでないチームメイトが地図から消える。
+--
+-- 所属チームをまたいで重複を除いた一覧を1回で返す。
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.list_my_teammates()
+RETURNS TABLE (id uuid, display_name text)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+STABLE
+AS $$
+  SELECT DISTINCT u.id, u."displayName"
+  FROM user_teams mine
+  JOIN user_teams theirs ON theirs."teamId" = mine."teamId"
+  JOIN users u ON u.id = theirs."userId"
+  WHERE mine."userId" = auth.uid()
+    AND auth.uid() IS NOT NULL;
+$$;
+
+
+-- ============================================================
+-- GRANT
+-- ============================================================
+
+GRANT EXECUTE ON FUNCTION public.get_public_profiles(uuid[]) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.search_users(text)          TO authenticated;
+GRANT EXECUTE ON FUNCTION public.list_my_teammates()         TO authenticated;
+
+REVOKE EXECUTE ON FUNCTION public.get_public_profiles(uuid[]) FROM anon, public;
+REVOKE EXECUTE ON FUNCTION public.search_users(text)          FROM anon, public;
+REVOKE EXECUTE ON FUNCTION public.list_my_teammates()         FROM anon, public;


### PR DESCRIPTION
## 概要

匿名で全ユーザーのメールアドレスが読める問題を修正します（#85）。**これで RLS 関連の漏洩はすべて塞がります。**

> ⚠️ **このPRは #93 を含みます**（`fix/restore-rls-policies` からブランチを切っているため）。#93 を先にマージすると、差分は `0018` と関連コードだけになります。

## 方針: Instagram / X と同じ考え方

あの2つは**検索を制限していません**。部分一致で誰でも探せます。それでも問題にならないのは、**公開してよい情報と絶対に出さない情報を分けている**からです。

| | Instagram / X | 修正前の daily-share |
|---|---|---|
| 表示名 | 公開（検索対象） | 公開 |
| **メールアドレス** | **絶対に出さない** | 🔴 一緒に返していた |
| 電話番号・生年月日 | 絶対に出さない | 🔴 返していた |

問題は「検索できること」ではなく、**検索結果に連絡先が混ざっていたこと**でした。

Postgres の RLS は行単位で列を制御できないため、次の形にしています。

1. `users` への**直接 SELECT を「自分の行のみ」**に絞る
2. **公開情報だけを返す RPC** を用意する

これで**検索の使い勝手は変えずに**、連絡先の漏洩だけが止まります。

## 追加した RPC（いずれも表示名しか返しません）

| 関数 | 用途 |
|---|---|
| `get_public_profiles(ids)` | フレンド一覧・招待候補・通知などの名前表示 |
| `search_users(query)` | ユーザー検索 |
| `list_my_teammates()` | 地図のチームメイト表示 |

`search_users` は**表示名を部分一致**で探せます（従来通り）。ただし**メールアドレスは完全一致のみ**にしました。部分一致だと総当たりでアドレスを探れてしまうためです。2文字未満のクエリも弾いています。

## 🔴 あわせて MapTab の不具合を修正しました

**PR #93 で「壊れるのは #86 だけ」と書きましたが、これは誤りでした。**

`MapTab` も `user_teams` を `.in('teamId', teamIds)` で直接引いてチームメイトを集めていました。`0017` で `user_teams_select` を本来の定義に戻した結果、**自分の行しか返らなくなります**。

これは表示名が欠けるだけの話ではありません。

```ts
// MapTab.tsx:215 — 表示名の有無でピンを出し分けている
(loc.userId === user?.id || knownNames.has(loc.userId))
```

**フレンドでないチームメイトが地図から消える**状態でした。`list_my_teammates()` RPC に置き換えて修正しています。

`user_teams` の全参照を洗い直し、残りは `useAuth`（`eq('userId', userId)` で自分の行）と各所の INSERT（自分の行）のみで、いずれも影響が無いことを確認しました。

## UX への影響

**フレンド一覧・検索結果からメールアドレスの表示が消えます。**

同名のユーザーを見分ける手段が無くなります。Instagram / X における `@ユーザー名` にあたる一意の識別子が現状無いためです。

身内利用の規模では実用上困らないと判断しましたが、**`@ユーザー名` の導入は別 issue として起票すべき**と考えています。今回は漏洩を止めることを優先しました。

## 適用済み・検証済み

`0018` は**本番に適用済み**です。

| 検証項目 | 修正前 | 修正後 |
|---|---|---|
| 匿名で `users` を読む | **21件（メール含む）** | **0件** ✅ |
| 匿名で `search_users` を叩く | — | **`42501` 拒否** ✅ |
| 匿名で `get_public_profiles` を叩く | — | **`42501` 拒否** ✅ |

### 全テーブルの最終確認（匿名・読み取り）

```
users 0 / teams 0 / user_teams 0 / team_messages 0 / events 0
locations 0 / user_friends 0 / friend_requests 0 / team_invitations 0
```

**9テーブルすべて 0 件**になりました。書き込みも #93 の時点で全テーブル `42501` を確認済みです。

- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm test`（54 passed）

⚠️ **ログインが必要な画面は未検証です。** 以下の確認をお願いします。

- フレンドタブ: 一覧の表示、**ユーザー検索**（表示名の一部・メール完全一致の両方）、申請の送受信
- 地図: **チームメイトのピンが表示されるか**（今回の修正の要）
- トークルーム: メンバー管理の「友だちを招待」候補

## 関連

- Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)
