### PR TITLE
fix(chat): 遡って読んでいる最中に新着で最下部へ飛ばされないようにする（#90）

### DIFF
--- a/src/components/Chat/RoomView.tsx
+++ b/src/components/Chat/RoomView.tsx
@@ -15,8 +15,9 @@ import {
 import { ArrowUpIcon, ArrowBackIcon } from '@chakra-ui/icons'
 import { supabase } from '../../lib/supabase'
 import { useTeamMembers } from '../../hooks/useTeamMembers'
+import { Button } from '../ui/Button'
 import { RoomMembersModal } from './RoomMembersModal'
-import { computeMessageFlags, formatDateLabel, formatTime } from './roomViewUtils'
+import { computeMessageFlags, formatDateLabel, formatTime, isNearBottom } from './roomViewUtils'
 import type { Database } from '../../types/database'
 
 type MessageRow = Database['public']['Tables']['team_messages']['Row']
@@ -43,6 +44,12 @@ export function RoomView({ team, currentUserId, onBack, onLeft }: RoomViewProps)
   const [draft, setDraft] = useState('')
   const [sending, setSending] = useState(false)
   const bottomRef = useRef<HTMLDivElement>(null)
+  const listRef = useRef<HTMLDivElement>(null)
+  // 最下部付近にいるか。描画のたびに読むだけなので state ではなく ref。
+  const atBottomRef = useRef(true)
+  const initialScrollDoneRef = useRef(false)
+  // 遡って読んでいる最中に届いた新着があるか。
+  const [hasNewBelow, setHasNewBelow] = useState(false)
   const membersDisclosure = useDisclosure()
 
   // 表示名は RPC 経由のメンバー一覧から引く（user_teams は自分の行しか見えないため）。
@@ -94,9 +101,40 @@ export function RoomView({ team, currentUserId, onBack, onLeft }: RoomViewProps)
     }
   }, [teamId, fetchMessages])
 
+  const scrollToBottom = useCallback((behavior: ScrollBehavior = 'smooth') => {
+    bottomRef.current?.scrollIntoView({ behavior })
+    setHasNewBelow(false)
+  }, [])
+
+  // スクロール位置を監視し、最下部付近にいるかを持つ。
+  const handleScroll = useCallback(() => {
+    const el = listRef.current
+    if (!el) return
+    const near = isNearBottom(el.scrollTop, el.scrollHeight, el.clientHeight)
+    atBottomRef.current = near
+    if (near) setHasNewBelow(false)
+  }, [])
+
+  // 新着が来たとき、最下部付近にいる場合だけ追従する。
+  // 遡って読んでいる最中に飛ばされると読書が中断されるため、
+  // その場合は「新着あり」を出すだけに留める。
   useEffect(() => {
-    bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
-  }, [messages])
+    if (messages.length === 0) return
+    if (atBottomRef.current) {
+      // 初回描画（ルームを開いた直後）はアニメーション無しで最下部へ。
+      scrollToBottom(initialScrollDoneRef.current ? 'smooth' : 'auto')
+      initialScrollDoneRef.current = true
+    } else {
+      setHasNewBelow(true)
+    }
+  }, [messages, scrollToBottom])
+
+  // ルームを切り替えたら、次の描画で最下部に着地させる。
+  useEffect(() => {
+    atBottomRef.current = true
+    initialScrollDoneRef.current = false
+    setHasNewBelow(false)
+  }, [teamId])
 
   const nameOf = useCallback(
     (id: string) => (id === currentUserId ? 'あなた' : memberNames.get(id) ?? 'メンバー'),
@@ -108,16 +146,26 @@ export function RoomView({ team, currentUserId, onBack, onLeft }: RoomViewProps)
     if (!body || !currentUserId) return
     setSending(true)
     try {
-      const { error } = await supabase
+      // 挿入した行をそのまま受け取って追加する。以前は全件再取得していたが、
+      // Realtime でも同じ行が届くため二重に処理され、スクロールがちらついていた。
+      // RETURNING は team_messages_select（所属チーム）を満たすので通る。
+      const { data: inserted, error } = await supabase
         .from('team_messages')
         .insert({ teamId, userId: currentUserId, body })
+        .select()
+        .single()
       if (error) {
         console.error('send message error', error)
         toast({ status: 'error', title: '送信できませんでした', description: error.message })
         return
       }
       setDraft('')
-      void fetchMessages(teamId)
+      if (inserted) {
+        setMessages((prev) => (prev.some((m) => m.id === inserted.id) ? prev : [...prev, inserted]))
+      }
+      // 自分が送ったときは、遡って読んでいても最下部へ戻す。
+      atBottomRef.current = true
+      scrollToBottom()
     } finally {
       setSending(false)
     }
@@ -140,7 +188,18 @@ export function RoomView({ team, currentUserId, onBack, onLeft }: RoomViewProps)
         />
       </HStack>
 
-      <Box h="calc(100vh - 300px)" minH="320px" overflowY="auto" px={3} py={4} bg={CHAT_BG}>
+      {/* position relative は「新着」ボタンを重ねるため */}
+      <Box position="relative">
+      <Box
+        ref={listRef}
+        onScroll={handleScroll}
+        h="calc(100vh - 300px)"
+        minH="320px"
+        overflowY="auto"
+        px={3}
+        py={4}
+        bg={CHAT_BG}
+      >
         {loading ? (
           <Center h="100%">
             <Spinner color="white" thickness="3px" />
@@ -210,6 +269,30 @@ export function RoomView({ team, currentUserId, onBack, onLeft }: RoomViewProps)
             <div ref={bottomRef} />
           </Box>
         )}
+      </Box>
+
+      {/* 遡って読んでいる最中に届いた新着への導線。
+          勝手にスクロールせず、本人が押したときだけ最下部へ戻す。 */}
+      {hasNewBelow && (
+        <Button
+          size="sm"
+          position="absolute"
+          bottom={3}
+          left="50%"
+          transform="translateX(-50%)"
+          borderRadius="full"
+          boxShadow="md"
+          bg="white"
+          color="gray.800"
+          _hover={{ bg: 'gray.50' }}
+          onClick={() => {
+            atBottomRef.current = true
+            scrollToBottom()
+          }}
+        >
+          新着メッセージ ↓
+        </Button>
+      )}
       </Box>
 
       <HStack p={2.5} borderTop="1px solid" borderColor="gray.200" bg="white" spacing={2}>

--- a/src/components/Chat/roomViewUtils.test.ts
+++ b/src/components/Chat/roomViewUtils.test.ts
@@ -4,6 +4,8 @@ import {
   formatDateLabel,
   formatTime,
   computeMessageFlags,
+  isNearBottom,
+  BOTTOM_THRESHOLD_PX,
   type MessageLike,
 } from './roomViewUtils'
 
@@ -69,6 +71,38 @@ describe('formatTime', () => {
 
   it('null は空文字', () => {
     expect(formatTime(null)).toBe('')
+  })
+})
+
+describe('isNearBottom', () => {
+  // scrollHeight 1000, clientHeight 400 → 最下部は scrollTop 600
+  it('ぴったり最下部なら true', () => {
+    expect(isNearBottom(600, 1000, 400)).toBe(true)
+  })
+
+  it('しきい値ちょうど手前なら true', () => {
+    expect(isNearBottom(600 - BOTTOM_THRESHOLD_PX, 1000, 400)).toBe(true)
+  })
+
+  it('しきい値を1px超えて離れていたら false', () => {
+    expect(isNearBottom(600 - BOTTOM_THRESHOLD_PX - 1, 1000, 400)).toBe(false)
+  })
+
+  it('大きく遡っていたら false', () => {
+    expect(isNearBottom(0, 1000, 400)).toBe(false)
+  })
+
+  it('内容が画面に収まりきる場合は true（スクロールできないため）', () => {
+    expect(isNearBottom(0, 300, 400)).toBe(true)
+  })
+
+  it('高さが同じ場合も true', () => {
+    expect(isNearBottom(0, 400, 400)).toBe(true)
+  })
+
+  it('しきい値を指定できる', () => {
+    expect(isNearBottom(500, 1000, 400, 100)).toBe(true)
+    expect(isNearBottom(500, 1000, 400, 50)).toBe(false)
   })
 })
 

--- a/src/components/Chat/roomViewUtils.ts
+++ b/src/components/Chat/roomViewUtils.ts
@@ -37,6 +37,30 @@ export function formatTime(iso: string | null) {
   })
 }
 
+/**
+ * 「最下部付近にいる」とみなす余白（px）。
+ * ぴったり最下部でなくても追従してほしいので、少し余裕を持たせる。
+ */
+export const BOTTOM_THRESHOLD_PX = 80
+
+/**
+ * スクロール位置が最下部付近かどうか。
+ *
+ * 新着メッセージで自動スクロールしてよいかの判定に使う。
+ * 過去を遡って読んでいる最中に最下部へ飛ばされると読書が中断されるため、
+ * 最下部付近にいるときだけ追従する。
+ */
+export function isNearBottom(
+  scrollTop: number,
+  scrollHeight: number,
+  clientHeight: number,
+  threshold: number = BOTTOM_THRESHOLD_PX,
+) {
+  // 内容が画面に収まりきる場合（スクロールできない場合）は残り距離が
+  // 0 以下になるため、この式だけで「最下部にいる」と判定される。
+  return scrollHeight - (scrollTop + clientHeight) <= threshold
+}
+
 /** フラグ計算に必要な最小限のメッセージ形。 */
 export interface MessageLike {
   userId: string


### PR DESCRIPTION
## 概要

トークルームで**過去を遡って読んでいる最中に、誰かが発言すると強制的に最下部へ飛ばされる**問題を修正します（#90）。

```ts
// before: メッセージ配列が変わるたび無条件にスクロール
useEffect(() => {
  bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
}, [messages])
```

## 修正内容

### 1. 最下部付近にいるときだけ追従する

一般的なチャットアプリと同じ挙動にしました。

| 状況 | 挙動 |
|---|---|
| 最下部付近にいる | 新着で自動追従（従来通り） |
| 遡って読んでいる | **その場に留まり**、「新着メッセージ ↓」を表示 |
| ボタンを押した | 最下部へ戻る |
| **自分が送信した** | 遡っていても最下部へ戻る |

判定は `roomViewUtils.isNearBottom` に切り出しました。しきい値は 80px で、ぴったり最下部でなくても追従します。

### 2. ルームを開いた直後の挙動

以前は `behavior: 'smooth'` 固定だったため、**開くたびに全履歴をスクロールする動きが見えていました**。初回は `'auto'` で即座に着地させます。ルーム切り替え時も初期化します。

### 3. 送信時の二重取得を解消（#90 の後半）

`insert` 後に**全件再取得**していましたが、Realtime でも同じ行が届くため二重に処理され、配列が丸ごと差し替わってスクロールがちらついていました。

`insert` の `RETURNING` で受け取った行を直接追加する形にしました。`team_messages_select` は所属チームを許可するので RETURNING は通ります。Realtime との重複は `id` で弾いています。

## 変異テストでデッドコードを発見しました

`isNearBottom` には当初こう書いていました。

```ts
if (scrollHeight <= clientHeight) return true   // 内容が収まりきる場合
return scrollHeight - (scrollTop + clientHeight) <= threshold
```

**この早期リターンを削除してもテストが1件も落ちませんでした。** 調べたところ、`scrollHeight <= clientHeight` のとき残り距離は必ず 0 以下になり、後続の式で同じ結果になる**デッドコード**でした。

削除し、意図はコメントとして残しています。テストの穴ではなく、コードの冗長性が原因でした。

## 確認

- [x] `npx tsc -b`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm test`（**61 passed** / 既存54 + 新規7）
- [x] dev サーバーでコンソールエラーが無いことを確認

### テストが実際に効くことを確認しました

| 壊した箇所 | 結果 |
|---|---|
| しきい値判定を潰す | **4件失敗** |
| 残り距離の計算を壊す | **4件失敗** |
| 復元 | 61件全pass |

⚠️ **スクロールの実挙動は未検証です。** ログインが必要なため、以下の確認をお願いします。

1. ルームを開いたとき、履歴をスクロールする動きが見えずに最下部へ着地するか
2. 上へ遡った状態で新着が来たとき、**その場に留まり「新着メッセージ ↓」が出るか**
3. そのボタンで最下部へ戻れるか
4. 自分が送信したとき、遡っていても最下部へ戻るか

## 関連

- Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)
