### PR TITLE
feat(ui): アバターの色をユーザーごとに散らして見分けやすくする

### DIFF
--- a/src/components/Account/AccountModal.tsx
+++ b/src/components/Account/AccountModal.tsx
@@ -22,6 +22,7 @@ import {
   Divider,
   useToast,
 } from '@chakra-ui/react'
+import { avatarColor } from '../../lib/avatarColor'
 import { useAuth } from '../../hooks/useAuth'
 import { Button } from '../ui/Button'
 import { Input } from '../ui/Input'
@@ -103,7 +104,7 @@ export function AccountModal({ isOpen, onClose, initialTab = 0 }: AccountModalPr
         <ModalBody>
           {/* Account summary */}
           <HStack spacing={3} mb={4}>
-            <Avatar size="md" name={form.displayName || email} bg="primary.500" color="white" />
+            <Avatar size="md" name={form.displayName || email} bg={avatarColor(user?.id)} color="white" />
             <Box minW={0}>
               <Text fontWeight="700" color="gray.900" noOfLines={1}>
                 {form.displayName || '名称未設定'}

--- a/src/components/Chat/RoomList.tsx
+++ b/src/components/Chat/RoomList.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Box, Flex, HStack, Text, Avatar, VStack } from '@chakra-ui/react'
+import { avatarColor } from '../../lib/avatarColor'
 import { supabase } from '../../lib/supabase'
 import type { Database } from '../../types/database'
 import {
@@ -118,7 +119,7 @@ export function RoomList({ teams, onSelect }: RoomListProps) {
             _hover={{ bg: 'gray.50' }}
             onClick={() => onSelect(t.id)}
           >
-            <Avatar name={t.teamName} bg="primary.500" color="white" />
+            <Avatar name={t.teamName} bg={avatarColor(t.id)} color="white" />
             <Box flex={1} minW={0}>
               <Flex justify="space-between" align="baseline" gap={2}>
                 <Text fontWeight="semibold" color="gray.900" noOfLines={1}>

--- a/src/components/Chat/RoomMembersModal.tsx
+++ b/src/components/Chat/RoomMembersModal.tsx
@@ -26,6 +26,7 @@ import {
   useClipboard,
   useToast,
 } from '@chakra-ui/react'
+import { avatarColor } from '../../lib/avatarColor'
 import { CopyIcon, CloseIcon, AddIcon } from '@chakra-ui/icons'
 import { supabase } from '../../lib/supabase'
 import { fetchPublicProfiles } from '../../lib/profiles'
@@ -250,7 +251,7 @@ export function RoomMembersModal({
                       const removable = canRemove && !isMe && (m.role !== 'admin' || isAdmin)
                       return (
                         <HStack key={m.userId} spacing={3}>
-                          <Avatar size="sm" name={m.displayName} bg="primary.500" color="white" />
+                          <Avatar size="sm" name={m.displayName} bg={avatarColor(m.userId)} color="white" />
                           <Box flex={1} minW={0}>
                             <Text fontSize="sm" color="gray.800" noOfLines={1}>
                               {m.displayName}
@@ -307,7 +308,7 @@ export function RoomMembersModal({
                     <VStack align="stretch" spacing={2}>
                       {invitations.map((inv) => (
                         <HStack key={inv.invitationId} spacing={3}>
-                          <Avatar size="sm" name={inv.inviteeName} bg="gray.300" color="white" />
+                          <Avatar size="sm" name={inv.inviteeName} bg={avatarColor(inv.inviteeId)} color="white" opacity={0.6} />
                           <Box flex={1} minW={0}>
                             <Text fontSize="sm" color="gray.800" noOfLines={1}>
                               {inv.inviteeName}
@@ -347,7 +348,7 @@ export function RoomMembersModal({
                   <VStack align="stretch" spacing={2}>
                     {invitableFriends.map((f) => (
                       <HStack key={f.id} spacing={3}>
-                        <Avatar size="sm" name={f.displayName} bg="gray.400" color="white" />
+                        <Avatar size="sm" name={f.displayName} bg={avatarColor(f.id)} color="white" />
                         <Text fontSize="sm" color="gray.800" flex={1} minW={0} noOfLines={1}>
                           {f.displayName}
                         </Text>

--- a/src/components/Chat/RoomView.tsx
+++ b/src/components/Chat/RoomView.tsx
@@ -12,6 +12,7 @@ import {
   useToast,
   useDisclosure,
 } from '@chakra-ui/react'
+import { avatarColor } from '../../lib/avatarColor'
 import { ArrowUpIcon, ArrowBackIcon } from '@chakra-ui/icons'
 import { supabase } from '../../lib/supabase'
 import { useTeamMembers } from '../../hooks/useTeamMembers'
@@ -176,7 +177,7 @@ export function RoomView({ team, currentUserId, onBack, onLeft }: RoomViewProps)
                   >
                     {!mine &&
                       (startGroup ? (
-                        <Avatar size="sm" name={nameOf(m.userId)} bg="primary.500" color="white" />
+                        <Avatar size="sm" name={nameOf(m.userId)} bg={avatarColor(m.userId)} color="white" />
                       ) : (
                         <Box w="32px" flexShrink={0} />
                       ))}

--- a/src/components/Friends/FriendsTab.tsx
+++ b/src/components/Friends/FriendsTab.tsx
@@ -13,6 +13,7 @@ import {
   Divider,
   useToast,
 } from '@chakra-ui/react'
+import { avatarColor } from '../../lib/avatarColor'
 import { supabase } from '../../lib/supabase'
 import { useAuth } from '../../hooks/useAuth'
 import { fetchPublicProfiles, searchUsers } from '../../lib/profiles'
@@ -178,7 +179,7 @@ export default function FriendsTab() {
     return (
       <HStack justify="space-between" spacing={3}>
         <HStack spacing={3} minW={0}>
-          <Avatar size="sm" name={person.displayName} bg="primary.500" color="white" />
+          <Avatar size="sm" name={person.displayName} bg={avatarColor(person.id)} color="white" />
           <Box minW={0}>
             <Text fontSize="sm" fontWeight="600" color="gray.800" noOfLines={1}>
               {person.displayName}

--- a/src/components/Layout/MainLayout.tsx
+++ b/src/components/Layout/MainLayout.tsx
@@ -21,6 +21,7 @@ import {
   Spinner,
   useDisclosure,
 } from '@chakra-ui/react'
+import { avatarColor } from '../../lib/avatarColor'
 import { useAuth } from '../../hooks/useAuth'
 import { Wordmark } from '../ui/Wordmark'
 import { AccountModal } from '../Account/AccountModal'
@@ -116,11 +117,11 @@ export function MainLayout() {
                   px={2}
                   borderRadius="full"
                 >
-                  <Avatar size="sm" name={name} bg="primary.500" color="white" />
+                  <Avatar size="sm" name={name} bg={avatarColor(user?.id)} color="white" />
                 </MenuButton>
                 <MenuList borderRadius="xl" borderColor="gray.200" boxShadow="lg" minW="240px">
                   <HStack px={3} py={2} spacing={3}>
-                    <Avatar size="sm" name={name} bg="primary.500" color="white" />
+                    <Avatar size="sm" name={name} bg={avatarColor(user?.id)} color="white" />
                     <Box minW={0}>
                       <Text fontWeight="semibold" color="gray.900" noOfLines={1}>
                         {name}

--- a/src/components/Map/MapTab.tsx
+++ b/src/components/Map/MapTab.tsx
@@ -22,6 +22,7 @@ import {
   Switch,
   FormLabel,
 } from '@chakra-ui/react'
+import { avatarColor } from '../../lib/avatarColor'
 import { supabase } from '../../lib/supabase'
 import { fetchPublicProfiles } from '../../lib/profiles'
 import { useAuth } from '../../hooks/useAuth'
@@ -504,7 +505,7 @@ export default function MapTab() {
                     onClick={() => focusPerson(p.pos)}
                   >
                     <HStack spacing={2}>
-                      <Avatar size="xs" name={p.name} bg="primary.500" color="white" />
+                      <Avatar size="xs" name={p.name} bg={avatarColor(p.id)} color="white" />
                       <Text fontSize="sm">{p.name}</Text>
                     </HStack>
                   </ListItem>

--- a/src/components/Notifications/NotificationBell.tsx
+++ b/src/components/Notifications/NotificationBell.tsx
@@ -16,6 +16,7 @@ import {
   Center,
   useToast,
 } from '@chakra-ui/react'
+import { avatarColor } from '../../lib/avatarColor'
 import { supabase } from '../../lib/supabase'
 import { useNotifications } from '../../hooks/useNotifications'
 
@@ -98,7 +99,7 @@ export function NotificationBell({ userId }: { userId: string | undefined }) {
               {friendRequests.map((n) => (
                 <Box key={n.requestId} px={2} py={2} borderRadius="md" _hover={{ bg: 'gray.50' }}>
                   <HStack spacing={3} align="start">
-                    <Avatar size="sm" name={n.requester.displayName} bg="primary.500" color="white" />
+                    <Avatar size="sm" name={n.requester.displayName} bg={avatarColor(n.requester.id)} color="white" />
                     <Box minW={0} flex={1}>
                       <Text fontSize="sm" color="gray.800">
                         <Text as="span" fontWeight="600">

--- a/src/components/Team/TeamsTab.tsx
+++ b/src/components/Team/TeamsTab.tsx
@@ -18,6 +18,7 @@ import {
   useClipboard,
   useToast,
 } from '@chakra-ui/react'
+import { avatarColor } from '../../lib/avatarColor'
 import { CopyIcon, AddIcon } from '@chakra-ui/icons'
 import { supabase } from '../../lib/supabase'
 import { useAuth } from '../../hooks/useAuth'
@@ -140,7 +141,7 @@ function TeamCard({
         <VStack align="stretch" spacing={2}>
           {members.map((m) => (
             <HStack key={m.userId} spacing={3}>
-              <Avatar size="xs" name={m.displayName} bg="primary.500" color="white" />
+              <Avatar size="xs" name={m.displayName} bg={avatarColor(m.userId)} color="white" />
               <Text fontSize="sm" color="gray.800">
                 {m.displayName}
                 {m.userId === currentUserId && (
@@ -211,7 +212,7 @@ function InvitationsCard({ onAccepted }: { onAccepted: () => Promise<void> | voi
       <VStack align="stretch" spacing={3}>
         {invitations.map((inv) => (
           <HStack key={inv.invitationId} spacing={3} wrap="wrap">
-            <Avatar size="sm" name={inv.teamName} bg="primary.500" color="white" />
+            <Avatar size="sm" name={inv.teamName} bg={avatarColor(inv.teamId)} color="white" />
             <Box flex={1} minW="140px">
               <Text fontSize="sm" fontWeight="semibold" color="gray.900" noOfLines={1}>
                 {inv.teamName}

--- a/src/lib/avatarColor.test.ts
+++ b/src/lib/avatarColor.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest'
+import { avatarColor, AVATAR_COLOR_COUNT } from './avatarColor'
+
+describe('avatarColor', () => {
+  it('同じ入力なら常に同じ色を返す', () => {
+    const id = 'd6e1329f-0fb9-4962-8752-48601c00ad28'
+    expect(avatarColor(id)).toBe(avatarColor(id))
+  })
+
+  it('null / undefined / 空文字はグレーにフォールバックする', () => {
+    expect(avatarColor(null)).toBe('gray.400')
+    expect(avatarColor(undefined)).toBe('gray.400')
+    expect(avatarColor('')).toBe('gray.400')
+  })
+
+  it('必ず定義済みの色を返す（範囲外にならない）', () => {
+    const colors = new Set<string>()
+    for (let i = 0; i < 500; i++) colors.add(avatarColor(`user-${i}`))
+    // gray へのフォールバックは起きない
+    expect(colors.has('gray.400')).toBe(false)
+    // 用意した色数を超えない
+    expect(colors.size).toBeLessThanOrEqual(AVATAR_COLOR_COUNT)
+  })
+
+  it('用意した色をひと通り使う（1色に偏らない）', () => {
+    const colors = new Set<string>()
+    for (let i = 0; i < 200; i++) colors.add(avatarColor(`user-${i}`))
+    expect(colors.size).toBe(AVATAR_COLOR_COUNT)
+  })
+
+  it('似た入力でも色が分かれる', () => {
+    // UUID は先頭が似ることがあるため、末尾違いで分散するか確認する
+    const a = avatarColor('00000000-0000-0000-0000-00000000000a')
+    const b = avatarColor('00000000-0000-0000-0000-00000000000b')
+    const c = avatarColor('00000000-0000-0000-0000-00000000000c')
+    expect(new Set([a, b, c]).size).toBeGreaterThan(1)
+  })
+
+  it('日本語の表示名でも落ちない', () => {
+    expect(avatarColor('田中太郎')).toMatch(/\./)
+    expect(avatarColor('やまだ')).toMatch(/\./)
+  })
+})

--- a/src/lib/avatarColor.ts
+++ b/src/lib/avatarColor.ts
@@ -1,0 +1,61 @@
+/**
+ * アバターの背景色を、ユーザーごとに散らして見分けやすくする。
+ *
+ * 全員が同じ色（primary.500）だと一覧で誰が誰だか分からないため、
+ * 識別子から決定的に色を選ぶ。同じ人はいつでも同じ色になり、
+ * 端末やセッションが変わってもぶれない。
+ *
+ * ランダムではなく決定的にするのは、再描画のたびに色が変わると
+ * かえって混乱するため。
+ */
+
+/**
+ * 背景に使う色。テーマのトークンから、白文字が読める濃さのものを選んである。
+ * 中間色（.400）だとコントラストが足りないので .500 以上を使う。
+ */
+const AVATAR_COLORS = [
+  'primary.500',
+  'signal.600',
+  'teal.500',
+  'purple.500',
+  'pink.500',
+  'cyan.600',
+  'orange.500',
+  'green.500',
+] as const
+
+/**
+ * 文字列から安定したハッシュを作る。暗号用途ではなく、色を散らすためだけのもの。
+ *
+ * djb2 で畳んだあと、最後にビットを撹拌している（xorshift 系の finalizer）。
+ * これが無いと下位ビットしか色の決定に効かず、UUID のように長くて似た
+ * 文字列が並ぶと特定の色に偏る。実際、撹拌前は24人中17人が2色に集中した。
+ */
+function hashString(input: string): number {
+  let hash = 5381
+  for (let i = 0; i < input.length; i++) {
+    hash = (Math.imul(hash, 33) ^ input.charCodeAt(i)) | 0
+  }
+  // avalanche: 上位ビットの差を下位へ広げる
+  let h = hash | 0
+  h ^= h >>> 16
+  h = Math.imul(h, 0x85ebca6b)
+  h ^= h >>> 13
+  h = Math.imul(h, 0xc2b2ae35)
+  h ^= h >>> 16
+  return h >>> 0
+}
+
+/**
+ * 識別子に対応する背景色を返す。
+ *
+ * userId のような不変の値を渡すのが望ましい。表示名を渡すと、
+ * 改名したときに色が変わる。
+ */
+export function avatarColor(seed: string | null | undefined): string {
+  if (!seed) return 'gray.400'
+  return AVATAR_COLORS[hashString(seed) % AVATAR_COLORS.length]
+}
+
+/** テスト・確認用に色数を公開する。 */
+export const AVATAR_COLOR_COUNT = AVATAR_COLORS.length


### PR DESCRIPTION
## 概要

**アバターが全員同じ青**で、一覧に並ぶと誰が誰だか分からない問題を直します。実際に使ってみてのフィードバックとして挙がった点です。

アプリ内 **13箇所すべて**が `bg="primary.500"` 固定でした。

## 対応

識別子から**決定的に**色を選ぶ `avatarColor` を追加しました。

```ts
<Avatar name={m.displayName} bg={avatarColor(m.userId)} color="white" />
```

**ランダムではなく決定的にしています。** 再描画のたびに色が変わるとかえって混乱するためで、同じ人はいつでも同じ色になります。端末やセッションが変わってもぶれません。

種には `userId`（チームは `teamId`）を使います。表示名を種にすると**改名で色が変わってしまう**ためです。

色はテーマのトークンから、白文字が読める濃さのものを8色選びました。

## ハッシュの偏りを直しました

当初 djb2 の下位ビットをそのまま `% 8` していましたが、**UUID のように長くて似た文字列が並ぶと偏りました**。

```
撹拌前（似た UUID 24人）        撹拌後
  signal.600  █████████ 9        green.500   █████ 5
  green.500   ████████ 8         purple.500  █████ 5
  cyan.600    ██ 2               cyan.600    ███ 3
  ...                            ...
  使われた色数: 6/8              使われた色数: 8/8
```

最後に xorshift 系の finalizer でビットを撹拌するようにしました。ランダムな UUID 200件でも8色にほぼ均等（19〜33件）に分かれることを確認しています。

## 確認

- [x] `npx tsc -b`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm test`（**60 passed** / 既存54 + 新規6）
- [x] 分布を実測（上記）

### テストが効くことを確認しました

撹拌処理と色の選択を壊すと **2件失敗**、復元で 60件全pass。

⚠️ **実画面での見え方は未検証です。** ログインが必要なため、一覧で色が分かれて見えるかの確認をお願いします。色味が好みに合わなければ `AVATAR_COLORS` の並びを変えるだけで調整できます。

## 補足

これは「個人間のやり取りができない」というもう一つのフィードバックとは別件です。そちらは機能追加になるので、設計を相談してから着手します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)