### PR TITLE
chore(sentry): イベントに release / environment を付け、有効化手順を文書化

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,21 +31,32 @@ VITE_SUPABASE_ANON_KEY=your-anon-key
 # ============================================================
 # エラートラッキング（Sentry）— 任意
 # ------------------------------------------------------------
-#   - 下の DSN を設定したときだけ Sentry が有効になる（未設定なら無効）。
+# 詳しい有効化手順は docs/sentry-setup.md にまとめてある。
+#
+#   - 下の DSN を設定したときだけ Sentry が有効になる（未設定なら無効。
+#     SDK の初期化コードごとビルドから除去されるので害は無い）。
 #     値の場所: Sentry → 対象プロジェクト → Settings → Client Keys (DSN)
 #   - 本番(Vercel)では Vercel の Environment Variables に登録する。
+#     **登録しただけでは反映されない。VITE_ 変数はビルド時に埋め込まれる
+#     ため、必ず再デプロイすること。**
 #   - DSN はブラウザに露出してよい公開値（anon key と同様）。
 # ============================================================
 # VITE_SENTRY_DSN=https://xxxxx@oyyyy.ingest.sentry.io/zzzzz
 
-# リリースタグ（任意）。どのデプロイで起きたかを紐付ける。
-# Vercel では VERCEL_GIT_COMMIT_SHA を渡すと良い。
+# --- 通常は設定しなくてよい ---------------------------------------------
+# release（どのデプロイで起きたか）と environment（本番/プレビューの
+# 切り分け）は、Vercel の VERCEL_GIT_COMMIT_SHA / VERCEL_ENV から
+# vite.config.ts が自動で決める。Vercel 以外でビルドする場合や、
+# 手で上書きしたいときだけ設定する。
 # VITE_SENTRY_RELEASE=
+# VITE_SENTRY_ENVIRONMENT=
 
 # --- ソースマップのアップロード（ビルド時のみ・任意） -------------------
-# 以下を設定したビルドだけ、Sentry にソースマップをアップロードして
-# 本番スタックトレースを元コードに復元できるようにする（未設定ならスキップ）。
+# 以下 3 つを設定したビルドだけ、Sentry にソースマップをアップロードして
+# 本番スタックトレースを元コードに復元できるようにする（未設定ならスキップ。
+# 1つでも欠けていればプラグインごと差し込まれず、ビルドは壊れない）。
+# これを設定しないと本番のスタックトレースは minify されたままで読めない。
 # これらはブラウザには露出しない（VITE_ プレフィックスを付けないこと）。
-#   SENTRY_AUTH_TOKEN=   # Sentry → Settings → Auth Tokens で発行
+#   SENTRY_AUTH_TOKEN=   # Sentry → Settings → Auth Tokens で発行（秘密）
 #   SENTRY_ORG=          # 組織スラッグ
 #   SENTRY_PROJECT=      # プロジェクトスラッグ

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,3 +110,14 @@ RLS is enabled on all tables. Auth trigger `handle_new_user()` auto-inserts into
 Copy `.env.example` to **`.env.local`** and fill in your Supabase project URL and anon key.
 
 > **`.env` ではなく `.env.local` を使うこと。** `.env` は過去に追跡されており（`4d6f8ea` で untrack）、古いブランチ 26 本が今も `.env` をツリーに持っている。gitignore は「切替先のコミットが追跡しているファイル」を守れないため、それらのブランチと `main` を `git checkout` で行き来すると**ディスク上の `.env` が消える**。`.env.local` はどのブランチも追跡していないので、この問題が起きない。Vite は `.env.local` を優先して読むため設定変更は不要。
+
+## エラー監視（Sentry）
+
+`src/lib/sentry.ts` で初期化し、`App.tsx` の `Sentry.ErrorBoundary` で描画クラッシュを捕捉する。収集対象は**未捕捉例外のみ**（トレース・リプレイは `tracesSampleRate: 0` で無効）。
+
+- **`VITE_SENTRY_DSN` を設定したときだけ有効。** 未設定ならビルドから SDK の初期化ごと除去され no-op になるため、ローカル開発では何も設定しなくてよい
+- `release` と `environment` は `vite.config.ts` が `VERCEL_GIT_COMMIT_SHA` / `VERCEL_ENV` から `define` でバンドルへ埋め込む。**ソースマップのアップロード時に使う release と同じ値を使うこと**（食い違うと本番のスタックトレースが復元されない）
+- ユーザー識別は `setSentryUser` で **ID のみ**。メール等の PII は送らない（`sendDefaultPii: false`）
+- **`supabase.from(...)` の失敗は届かない。** エラーを throw せず戻り値で返すため、拾いたい箇所に `Sentry.captureException` を足す必要がある
+
+有効化手順（DSN 登録・通知設定・ソースマップ）は **[docs/sentry-setup.md](docs/sentry-setup.md)** に集約してある。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,7 +116,7 @@ Copy `.env.example` to **`.env.local`** and fill in your Supabase project URL an
 `src/lib/sentry.ts` で初期化し、`App.tsx` の `Sentry.ErrorBoundary` で描画クラッシュを捕捉する。収集対象は**未捕捉例外のみ**（トレース・リプレイは `tracesSampleRate: 0` で無効）。
 
 - **`VITE_SENTRY_DSN` を設定したときだけ有効。** 未設定ならビルドから SDK の初期化ごと除去され no-op になるため、ローカル開発では何も設定しなくてよい
-- `release` と `environment` は `vite.config.ts` が `VERCEL_GIT_COMMIT_SHA` / `VERCEL_ENV` から `define` でバンドルへ埋め込む。**ソースマップのアップロード時に使う release と同じ値を使うこと**（食い違うと本番のスタックトレースが復元されない）
+- `release` と `environment` は `vite.config.ts` が `VERCEL_GIT_COMMIT_SHA` / `VERCEL_ENV` から `define` でバンドルへ埋め込む。`Sentry.init` に `release: undefined` を渡すと、プラグインが注入した `__SENTRY_RELEASE__` を上書きしてイベントに release が付かなくなるので注意（ソースマップの突き合わせ自体は debug ID で行われるため release とは独立）
 - ユーザー識別は `setSentryUser` で **ID のみ**。メール等の PII は送らない（`sendDefaultPii: false`）
 - **`supabase.from(...)` の失敗は届かない。** エラーを throw せず戻り値で返すため、拾いたい箇所に `Sentry.captureException` を足す必要がある
 

--- a/docs/sentry-setup.md
+++ b/docs/sentry-setup.md
@@ -1,0 +1,158 @@
+# Sentry 有効化手順（エラー監視）
+
+本番の未捕捉エラーを Sentry に集めて通知するための手順書。issue #52 の残作業はこのファイルの通りに進める。
+
+## 現状
+
+**コードの組み込みは完了している**（PR #81、`main` にマージ済み）。
+
+| ファイル | 役割 |
+|---|---|
+| `src/lib/sentry.ts` | `Sentry.init()` / ユーザー ID の紐付け |
+| `src/main.tsx` | 描画前に `initSentry()` を呼ぶ |
+| `src/App.tsx` | `Sentry.ErrorBoundary` で描画クラッシュを捕捉 |
+| `src/components/ErrorFallback.tsx` | クラッシュ時に出す画面 |
+| `vite.config.ts` | release / environment の埋め込み、ソースマップのアップロード |
+
+**残っているのは DSN の登録だけ。** DSN が未設定の間 `initSentry()` は何もせず、Sentry SDK の初期化コードはビルドから除去される（no-op。バンドルも太らない）。
+
+> **`VITE_` 変数はビルド時にバンドルへ埋め込まれる。** 環境変数を登録しただけでは反映されない。**必ず再デプロイすること。**
+
+---
+
+## 手順
+
+### 1. Sentry プロジェクトを作る
+
+1. https://sentry.io でログイン（アカウントが無ければ作成）
+2. **Projects → Create Project**
+3. Platform に **React** を選ぶ
+4. プロジェクト名は `daily-share`
+5. 作成後に表示されるコード例は**不要**（すでに実装済み）。DSN だけ控える
+
+DSN は後からでも **Settings → Projects → daily-share → Client Keys (DSN)** で確認できる。
+`https://<公開キー>@o<組織ID>.ingest.sentry.io/<プロジェクトID>` の形。
+
+> DSN はブラウザに露出してよい公開値（Supabase の anon key と同じ扱い）。秘密ではないが、後述の `SENTRY_AUTH_TOKEN` は**秘密**なので混同しないこと。
+
+### 2. Vercel に DSN を登録する
+
+Vercel → daily-share → **Settings → Environment Variables**
+
+| Key | Value | 対象環境 |
+|---|---|---|
+| `VITE_SENTRY_DSN` | 手順 1 の DSN | Production / Preview |
+
+Preview にも入れておくと、本番前のデプロイで出たエラーも拾える。Sentry 側では `environment` が `production` / `preview` に自動で分かれるため、混ざって困ることはない（`vite.config.ts` が `VERCEL_ENV` から決めている）。
+
+Preview のノイズが邪魔なら Production だけに入れる。
+
+> **`VITE_SENTRY_RELEASE` / `VITE_SENTRY_ENVIRONMENT` は登録しなくてよい。** Vercel が渡す `VERCEL_GIT_COMMIT_SHA` / `VERCEL_ENV` から自動で決まる。ローカルや他のホスティングで上書きしたいときだけ使う。
+
+### 3. 再デプロイする
+
+Vercel → **Deployments → 最新のデプロイ → ⋯ → Redeploy**。
+
+「Use existing Build Cache」は**外す**（環境変数を確実に読み直させる）。
+
+### 4. エラーが届くか確認する
+
+1. 本番 URL を開く
+2. DevTools のコンソールで、わざと未捕捉エラーを起こす
+
+```js
+setTimeout(() => { throw new Error('Sentry test: 本番疎通確認') })
+```
+
+3. Sentry の **Issues** に `Sentry test: 本番疎通確認` が数秒〜1分で現れる
+
+イベントを開いて、次の 2 つが付いていることも確認する。
+
+- **release** = デプロイした commit SHA
+- **environment** = `production`
+
+> **広告ブロッカーやトラッキング防止機能が Sentry への送信をブロックすることがある。** イベントが来ないときは拡張機能を切ったブラウザ、またはシークレットウィンドウで試す。Network タブで `ingest.sentry.io` へのリクエストが失敗していれば原因はこれ。
+
+確認が終わったら、そのテスト issue は Sentry 上で **Resolve** か **Delete** しておく。
+
+### 5. 通知を設定する（これが無いと気づけない）
+
+イベントが溜まっても、通知が無ければ障害に気づけない。issue #52 の完了条件は「収集**・通知**」なのでここまでやる。
+
+Sentry → **Alerts → Create Alert → Issues**
+
+- 推奨条件: **A new issue is created**（新しい種類のエラーが出たときだけ通知。同じエラーの連発では鳴らない）
+- Action: 自分のメールアドレス
+- Slack を使っているなら **Settings → Integrations → Slack** を接続してチャンネル通知も追加する
+
+エラーが多くて煩わしくなったら、条件を「短時間に N 件以上」へ変える。
+
+### 6.（任意）ソースマップをアップロードする
+
+これをやらないと、本番のスタックトレースが minify されたコード（`z_`, `W_` のような名前）のままで読めない。**実質必須に近い。**
+
+1. Sentry → **Settings → Auth Tokens → Create New Token**
+   - 必要なスコープ: `project:releases`（と `org:read`）
+2. Vercel の Environment Variables に 3 つ登録する
+
+| Key | Value | 備考 |
+|---|---|---|
+| `SENTRY_AUTH_TOKEN` | 手順 1 のトークン | **秘密。`VITE_` を付けないこと**（付けるとブラウザに漏れる） |
+| `SENTRY_ORG` | 組織スラッグ | Sentry の URL に出る |
+| `SENTRY_PROJECT` | `daily-share` | プロジェクトスラッグ |
+
+3. 再デプロイする
+
+3 つ揃ったビルドだけソースマップを生成・アップロードし、アップロード後に `.map` を削除する（公開ディレクトリに残さない）。1 つでも欠けていればプラグインごとスキップされ、ビルドは壊れない。
+
+確認方法: 手順 4 のテストエラーをもう一度出し、スタックトレースに `src/...` の TSX の行が出ていれば成功。
+
+---
+
+## 環境変数まとめ
+
+| 変数 | 必須 | ブラウザに露出 | 用途 |
+|---|---|---|---|
+| `VITE_SENTRY_DSN` | ○ | する（公開値でよい） | これが無いと Sentry は完全に無効 |
+| `SENTRY_AUTH_TOKEN` | 任意 | **しない** | ソースマップのアップロード |
+| `SENTRY_ORG` | 任意 | しない | 同上 |
+| `SENTRY_PROJECT` | 任意 | しない | 同上 |
+| `VITE_SENTRY_RELEASE` | 不要 | する | Vercel では commit SHA から自動 |
+| `VITE_SENTRY_ENVIRONMENT` | 不要 | する | Vercel では `VERCEL_ENV` から自動 |
+
+ローカルで試す場合は `.env.local` に `VITE_SENTRY_DSN` を入れて `npm run dev` を再起動する。ただし開発中のエラーまで本番プロジェクトに混ざるため、常用は勧めない（`environment` が `development` になるのでフィルタは可能）。
+
+---
+
+## 収集される / されないもの
+
+**収集される**
+
+- 未捕捉の例外（`window.onerror`）
+- 未処理の Promise rejection
+- React の描画中クラッシュ（`Sentry.ErrorBoundary`）
+- エラーの発生ユーザー（**ID のみ**。メール・氏名は送らない。`sendDefaultPii: false`）
+
+**収集されない**
+
+- **Supabase 呼び出しの失敗。** `supabase.from(...)` はエラーを throw せず戻り値で返すため、`console.error` している箇所は Sentry に届かない。RLS 違反やネットワーク断はここに出るので、**取りこぼしとしては一番大きい**。拾いたい箇所から順に `Sentry.captureException(error)` を足していく
+- パフォーマンス（トレース）とセッションリプレイ。`tracesSampleRate: 0` で無効。有料枠を使うため意図的に切っている
+- Supabase Edge Functions。**そもそもこのリポジトリに Edge Functions は無い**（`supabase/` は migrations のみ）。追加したらサーバ側の Sentry も別途入れる
+
+---
+
+## トラブルシュート
+
+| 症状 | 原因 |
+|---|---|
+| Issues に何も来ない | ①再デプロイしていない（`VITE_` はビルド時埋め込み） ②DSN の対象環境が Production になっていない ③広告ブロッカーが送信をブロック |
+| スタックトレースが読めない | ソースマップ未設定（手順 6） |
+| release が付かない／`unknown` | Vercel 以外でビルドしている。`VITE_SENTRY_RELEASE` を明示的に渡す |
+| ソースマップを上げたのに復元されない | ビルド時の release と実行時の release が食い違っている。両方 `vite.config.ts` の同じ値から決まるので、通常は起きない。手で `VITE_SENTRY_RELEASE` を設定した場合は値を揃える |
+| Preview のエラーが煩わしい | `VITE_SENTRY_DSN` を Production 限定にする、または Sentry 側で `environment:production` のフィルタ／アラート条件を使う |
+
+---
+
+## 完了したら
+
+issue #52 をクローズする。完了条件は「本番の未捕捉エラーが収集・通知される」なので、**手順 5 の通知まで終わってから**閉じること。

--- a/docs/sentry-setup.md
+++ b/docs/sentry-setup.md
@@ -107,20 +107,21 @@ Sentry → **Alerts → Create Alert → Issues**
 
 ### アップロードの失敗はデプロイを止めない
 
-**上のどれかを間違えても、Vercel のデプロイは成功する。** `vite.config.ts` で `errorHandler` を渡しているため、アップロードの失敗は警告だけでビルドは通る（監視の設定ミスでアプリを出せなくなる方が損失が大きいため、意図的にそうしている）。
+**上のどれかを間違えても、Vercel のデプロイは成功する。** アップロードの失敗はログに出るだけでビルドは通る（実測で確認済み。`errorHandler` を渡していない状態でも終了コードは 0 だった）。`vite.config.ts` の `errorHandler` は、その失敗を読みやすい 1 行に置き換えているだけで、成功・失敗の分岐を変えるものではない。
 
 裏を返すと、**失敗しても気づけない。** 必ず次のどれかで確認する。
 
-- Vercel の Build Logs に `[sentry-vite-plugin] ソースマップのアップロードに失敗しました` が出ていないか
+- Vercel の Build Logs に `[sentry-vite-plugin]` の失敗行（`ソースマップのアップロードに失敗しました` / `Couldn't finish all operations`）が出ていないか
 - Sentry → **Releases** に commit SHA の release があり、artifacts が 0 件でないか
 - 手順 4 のテストエラーをもう一度出し、スタックトレースに `src/...` の TSX の行と前後のコードが出るか
 
 ### ソースマップ自体は公開されない
 
-`.map` は元コードそのものなので、公開ディレクトリに残すと誰でもソースを読める。二重に対策してある。
+`.map` は元コードそのものなので、公開ディレクトリに残すと誰でもソースを読める。三重に対策してある。
 
-- `build.sourcemap: 'hidden'` — `.map` は作るが、バンドルに `sourceMappingURL` コメントを埋め込まない（ブラウザが勝手に取得しない）。Sentry は debug ID で突き合わせるため影響しない
-- ビルドの最後に `dist` 配下の `.map` を必ず削除する（`deleteLeftoverSourcemaps` プラグイン）。アップロードが失敗した場合も残らない
+- `sentryVitePlugin` の `filesToDeleteAfterUpload` が `./dist/**/*.map` を削除する。**アップロードが失敗した場合も削除される**（実測確認済み）
+- `build.sourcemap: 'hidden'` — `.map` は作るが、バンドルに `sourceMappingURL` コメントを埋め込まない。Sentry は debug ID で突き合わせるため復元には影響せず、削除済みの `.map` を DevTools が取りに行って 404 になることも無くなる
+- `deleteLeftoverSourcemaps` プラグインがビルドの最後に `.map` を消す。上の `filesToDeleteAfterUpload` は `./dist` 決め打ちなので、出力先を変えたときに漏れる。その保険
 
 ---
 
@@ -164,7 +165,8 @@ Sentry → **Alerts → Create Alert → Issues**
 | スタックトレースが読めない | ソースマップ未設定（手順 6） |
 | デプロイは成功したのにスタックトレースが読めない | アップロードだけ失敗している（失敗してもビルドは通る仕様）。Vercel の Build Logs で `[sentry-vite-plugin]` の警告を確認する。`SENTRY_ORG` / `SENTRY_PROJECT` の登録漏れ、トークンのスコープ不足（`project:releases` が必要）が典型 |
 | release が付かない／`unknown` | Vercel 以外でビルドしている。`VITE_SENTRY_RELEASE` を明示的に渡す |
-| ソースマップを上げたのに復元されない | ビルド時の release と実行時の release が食い違っている。両方 `vite.config.ts` の同じ値から決まるので、通常は起きない。手で `VITE_SENTRY_RELEASE` を設定した場合は値を揃える |
+| ソースマップを上げたのに復元されない | 突き合わせは release ではなく **debug ID** で行われるため、release の食い違いが原因ではない。アップロード自体が失敗している可能性が高いので Build Logs を見る |
+| Issues に release が付かない（Releases に artifacts はあるのに紐付かない） | 実行時に `release` を渡していない。`vite.config.ts` の `define` した値を `src/lib/sentry.ts` が読む構成になっているか確認する（`release: undefined` を明示的に渡すと、プラグインが注入した `__SENTRY_RELEASE__` を上書きしてしまう） |
 | Preview のエラーが煩わしい | `VITE_SENTRY_DSN` を Production 限定にする、または Sentry 側で `environment:production` のフィルタ／アラート条件を使う |
 
 ---

--- a/docs/sentry-setup.md
+++ b/docs/sentry-setup.md
@@ -101,11 +101,26 @@ Sentry → **Alerts → Create Alert → Issues**
 | `SENTRY_ORG` | 組織スラッグ | Sentry の URL に出る |
 | `SENTRY_PROJECT` | `daily-share` | プロジェクトスラッグ |
 
+**`SENTRY_ORG` と `SENTRY_PROJECT` も必ず登録すること。** `vite.config.ts` にハードコードしていないので、3 つ揃わないとアップロード処理ごとスキップされる（トークンだけでは何も起きない）。
+
 3. 再デプロイする
 
-3 つ揃ったビルドだけソースマップを生成・アップロードし、アップロード後に `.map` を削除する（公開ディレクトリに残さない）。1 つでも欠けていればプラグインごとスキップされ、ビルドは壊れない。
+### アップロードの失敗はデプロイを止めない
 
-確認方法: 手順 4 のテストエラーをもう一度出し、スタックトレースに `src/...` の TSX の行が出ていれば成功。
+**上のどれかを間違えても、Vercel のデプロイは成功する。** `vite.config.ts` で `errorHandler` を渡しているため、アップロードの失敗は警告だけでビルドは通る（監視の設定ミスでアプリを出せなくなる方が損失が大きいため、意図的にそうしている）。
+
+裏を返すと、**失敗しても気づけない。** 必ず次のどれかで確認する。
+
+- Vercel の Build Logs に `[sentry-vite-plugin] ソースマップのアップロードに失敗しました` が出ていないか
+- Sentry → **Releases** に commit SHA の release があり、artifacts が 0 件でないか
+- 手順 4 のテストエラーをもう一度出し、スタックトレースに `src/...` の TSX の行と前後のコードが出るか
+
+### ソースマップ自体は公開されない
+
+`.map` は元コードそのものなので、公開ディレクトリに残すと誰でもソースを読める。二重に対策してある。
+
+- `build.sourcemap: 'hidden'` — `.map` は作るが、バンドルに `sourceMappingURL` コメントを埋め込まない（ブラウザが勝手に取得しない）。Sentry は debug ID で突き合わせるため影響しない
+- ビルドの最後に `dist` 配下の `.map` を必ず削除する（`deleteLeftoverSourcemaps` プラグイン）。アップロードが失敗した場合も残らない
 
 ---
 
@@ -147,6 +162,7 @@ Sentry → **Alerts → Create Alert → Issues**
 |---|---|
 | Issues に何も来ない | ①再デプロイしていない（`VITE_` はビルド時埋め込み） ②DSN の対象環境が Production になっていない ③広告ブロッカーが送信をブロック |
 | スタックトレースが読めない | ソースマップ未設定（手順 6） |
+| デプロイは成功したのにスタックトレースが読めない | アップロードだけ失敗している（失敗してもビルドは通る仕様）。Vercel の Build Logs で `[sentry-vite-plugin]` の警告を確認する。`SENTRY_ORG` / `SENTRY_PROJECT` の登録漏れ、トークンのスコープ不足（`project:releases` が必要）が典型 |
 | release が付かない／`unknown` | Vercel 以外でビルドしている。`VITE_SENTRY_RELEASE` を明示的に渡す |
 | ソースマップを上げたのに復元されない | ビルド時の release と実行時の release が食い違っている。両方 `vite.config.ts` の同じ値から決まるので、通常は起きない。手で `VITE_SENTRY_RELEASE` を設定した場合は値を揃える |
 | Preview のエラーが煩わしい | `VITE_SENTRY_DSN` を Production 限定にする、または Sentry 側で `environment:production` のフィルタ／アラート条件を使う |

--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -3,10 +3,19 @@ import * as Sentry from '@sentry/react'
 // 実行時の DSN。未設定（ローカル開発や DSN を登録していない環境）では
 // Sentry を一切初期化せず no-op にする。これにより .env が無くても
 // 開発・テストが妨げられない。
-const dsn = import.meta.env.VITE_SENTRY_DSN as string | undefined
+const dsn = import.meta.env.VITE_SENTRY_DSN
 
 /** Sentry が有効化されているか（DSN が設定されているか）。 */
 export const sentryEnabled = Boolean(dsn)
+
+// どのデプロイで起きたか。vite.config.ts が commit SHA を埋め込む。
+// **ソースマップのアップロード時に使う release と必ず同じ値**（食い違うと
+// 本番のスタックトレースが元コードに復元されない）。
+const release = __SENTRY_RELEASE__ || import.meta.env.VITE_SENTRY_RELEASE || undefined
+
+// 本番とプレビューを Sentry 上で分けるための環境名。Vercel では
+// VERCEL_ENV（production / preview）が入る。無ければ Vite のモード。
+const environment = __SENTRY_ENVIRONMENT__ || import.meta.env.MODE
 
 /**
  * Sentry を初期化する。`main.tsx` で描画前に一度だけ呼ぶ。
@@ -20,11 +29,10 @@ export function initSentry() {
 
   Sentry.init({
     dsn,
-    // 'production' / 'development' など Vite のモードをそのまま使う。
-    environment: import.meta.env.MODE,
-    // どのデプロイで起きたかを紐付けるリリースタグ（任意）。
-    // ビルド時に VITE_SENTRY_RELEASE（例: コミット SHA）を渡すと有効。
-    release: (import.meta.env.VITE_SENTRY_RELEASE as string | undefined) || undefined,
+    // 'production' / 'preview' など。Sentry 上で本番とプレビューを分ける。
+    environment,
+    // どのデプロイで起きたかを紐付けるリリースタグ。
+    release,
     // メール等の PII を自動付与しない。ユーザー識別は setSentryUser で
     // 最小限（ID のみ）を明示的に送る。
     sendDefaultPii: false,

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,24 @@
+/// <reference types="vite/client" />
+
+/**
+ * ビルド時に vite.config.ts の `define` で埋め込まれる定数。
+ * 値が無いビルド（ローカル開発など）では空文字列になる。
+ */
+declare const __SENTRY_RELEASE__: string
+declare const __SENTRY_ENVIRONMENT__: string
+
+/** `.env.local` / Vercel の Environment Variables で渡す実行時の設定。 */
+interface ImportMetaEnv {
+  readonly VITE_SUPABASE_URL: string
+  readonly VITE_SUPABASE_ANON_KEY: string
+  /** 設定したときだけ Sentry が有効になる。未設定なら no-op。 */
+  readonly VITE_SENTRY_DSN?: string
+  /** 通常は不要（Vercel では commit SHA から自動で決まる）。 */
+  readonly VITE_SENTRY_RELEASE?: string
+  /** 通常は不要（Vercel では VERCEL_ENV から自動で決まる）。 */
+  readonly VITE_SENTRY_ENVIRONMENT?: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,10 @@
 /// <reference types="vitest/config" />
-import { defineConfig } from 'vite';
+import { defineConfig, type Plugin } from 'vite';
 import react from '@vitejs/plugin-react';
 import { sentryVitePlugin } from '@sentry/vite-plugin';
 
 // https://vite.dev/config/
+import fs from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { storybookTest } from '@storybook/addon-vitest/vitest-plugin';
@@ -29,6 +30,44 @@ const sentryEnvironment = process.env.VITE_SENTRY_ENVIRONMENT || process.env.VER
 // プラグインを差し込まず、ソースマップも生成しない（ビルドは壊れない）。
 const uploadSourcemaps = Boolean(sentryAuthToken && sentryOrg && sentryProject);
 
+/**
+ * ビルド出力に残った `.map` を必ず削除する。
+ *
+ * ソースマップは**元コードそのもの**なので、公開ディレクトリに残すと
+ * 誰でもアプリのソースを読める。sentryVitePlugin の
+ * `filesToDeleteAfterUpload` はアップロードが成功したときだけ動くため、
+ * トークン不正・ネットワーク断で失敗すると `.map` が dist に残り、
+ * そのまま本番へデプロイされてしまう。その取りこぼしを塞ぐ。
+ *
+ * `closeBundle` は全プラグインの `writeBundle`（Sentry のアップロードは
+ * ここで走る）が終わったあとに呼ばれるので、アップロードを邪魔しない。
+ */
+function deleteLeftoverSourcemaps(): Plugin {
+  let outDir = '';
+  return {
+    name: 'delete-leftover-sourcemaps',
+    apply: 'build',
+    configResolved(config) {
+      outDir = path.resolve(config.root, config.build.outDir);
+    },
+    async closeBundle() {
+      let entries: string[];
+      try {
+        entries = await fs.readdir(outDir, { recursive: true });
+      } catch {
+        return; // 出力が無い（ライブラリビルド等）ときは何もしない
+      }
+      const maps = entries.filter((entry) => entry.endsWith('.map'));
+      await Promise.all(maps.map((map) => fs.rm(path.join(outDir, map), { force: true })));
+      if (maps.length > 0) {
+        console.warn(
+          `[sourcemaps] アップロードされずに残った .map を ${maps.length} 件削除しました（公開防止）`,
+        );
+      }
+    },
+  };
+}
+
 // More info at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon
 export default defineConfig({
   plugins: [
@@ -43,7 +82,21 @@ export default defineConfig({
             project: sentryProject,
             release: sentryRelease ? { name: sentryRelease } : undefined,
             sourcemaps: { filesToDeleteAfterUpload: ['./dist/**/*.map'] },
+            // **アップロードの失敗でデプロイを落とさない。** 既定では
+            // throw してビルドを止めるため、トークンの期限切れ・スコープ
+            // 不足・スラッグ違いといった監視側の設定ミスで、アプリの
+            // デプロイごと失敗する。それより警告に留めて出す方が安全。
+            // 上がったかどうかは Sentry の Releases で確認する
+            // （docs/sentry-setup.md 手順 6）。
+            errorHandler: (err) => {
+              console.warn(
+                '[sentry-vite-plugin] ソースマップのアップロードに失敗しました（ビルドは継続します）:',
+                err.message,
+              );
+            },
           }),
+          // 取りこぼした .map を最後に必ず消す（Sentry プラグインより後）。
+          deleteLeftoverSourcemaps(),
         ]
       : []),
   ],
@@ -53,9 +106,12 @@ export default defineConfig({
     __SENTRY_RELEASE__: JSON.stringify(sentryRelease),
     __SENTRY_ENVIRONMENT__: JSON.stringify(sentryEnvironment),
   },
-  // ソースマップはアップロードする時だけ生成する。
+  // ソースマップはアップロードする時だけ生成する。'hidden' は .map を作るが
+  // バンドルに sourceMappingURL コメントを埋め込まない = ブラウザが勝手に
+  // 取りに行かない。Sentry は debug ID で突き合わせるため影響しない
+  // （Sentry 推奨の設定）。
   build: {
-    sourcemap: uploadSourcemaps,
+    sourcemap: uploadSourcemaps ? 'hidden' : false,
   },
   test: {
     projects: [{

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -35,9 +35,9 @@ const uploadSourcemaps = Boolean(sentryAuthToken && sentryOrg && sentryProject);
  *
  * ソースマップは**元コードそのもの**なので、公開ディレクトリに残すと
  * 誰でもアプリのソースを読める。sentryVitePlugin の
- * `filesToDeleteAfterUpload` はアップロードが成功したときだけ動くため、
- * トークン不正・ネットワーク断で失敗すると `.map` が dist に残り、
- * そのまま本番へデプロイされてしまう。その取りこぼしを塞ぐ。
+ * `filesToDeleteAfterUpload` は失敗時にも削除してくれるが、パスが
+ * `./dist` 決め打ちなので、出力先を変えると（`--outDir` 等）取りこぼす。
+ * その保険として、実際の出力先を見て確実に消す。
  *
  * `closeBundle` は全プラグインの `writeBundle`（Sentry のアップロードは
  * ここで走る）が終わったあとに呼ばれるので、アップロードを邪魔しない。
@@ -82,12 +82,11 @@ export default defineConfig({
             project: sentryProject,
             release: sentryRelease ? { name: sentryRelease } : undefined,
             sourcemaps: { filesToDeleteAfterUpload: ['./dist/**/*.map'] },
-            // **アップロードの失敗でデプロイを落とさない。** 既定では
-            // throw してビルドを止めるため、トークンの期限切れ・スコープ
-            // 不足・スラッグ違いといった監視側の設定ミスで、アプリの
-            // デプロイごと失敗する。それより警告に留めて出す方が安全。
-            // 上がったかどうかは Sentry の Releases で確認する
-            // （docs/sentry-setup.md 手順 6）。
+            // アップロードの失敗を読みやすい 1 行に置き換える。既定でも
+            // ビルドは通る（実測: 失敗しても終了コードは 0）ので、これは
+            // 挙動を変えるものではなく、長いスタックトレースに埋もれて
+            // 見落とすのを防ぐためのもの。上がったかどうかは Sentry の
+            // Releases で確認する（docs/sentry-setup.md 手順 6）。
             errorHandler: (err) => {
               console.warn(
                 '[sentry-vite-plugin] ソースマップのアップロードに失敗しました（ビルドは継続します）:',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,9 +15,16 @@ const dirname = typeof __dirname !== 'undefined' ? __dirname : path.dirname(file
 const sentryAuthToken = process.env.SENTRY_AUTH_TOKEN;
 const sentryOrg = process.env.SENTRY_ORG;
 const sentryProject = process.env.SENTRY_PROJECT;
-// 実行時の release（VITE_SENTRY_RELEASE）と一致させる。Vercel では
-// VERCEL_GIT_COMMIT_SHA をフォールバックに使う。
-const sentryRelease = process.env.VITE_SENTRY_RELEASE || process.env.VERCEL_GIT_COMMIT_SHA;
+// release（どのデプロイで起きたか）。Vercel では VERCEL_GIT_COMMIT_SHA を
+// フォールバックに使うので、Vercel 側で追加の設定は不要。
+// この値はソースマップのアップロード先タグと、実行時に Sentry へ送る
+// release の両方に使う。**両者が一致しないとソースマップが適用されない**
+// ため、下の define で同じ定数をブラウザ側へ埋め込んでいる。
+const sentryRelease = process.env.VITE_SENTRY_RELEASE || process.env.VERCEL_GIT_COMMIT_SHA || '';
+// environment（本番 / プレビューの切り分け）。Vercel の VERCEL_ENV は
+// 'production' | 'preview' | 'development' を返す。未設定ならブラウザ側で
+// import.meta.env.MODE にフォールバックする。
+const sentryEnvironment = process.env.VITE_SENTRY_ENVIRONMENT || process.env.VERCEL_ENV || '';
 // 3 つの認証情報が揃ったビルドだけアップロードする。揃っていなければ
 // プラグインを差し込まず、ソースマップも生成しない（ビルドは壊れない）。
 const uploadSourcemaps = Boolean(sentryAuthToken && sentryOrg && sentryProject);
@@ -40,6 +47,12 @@ export default defineConfig({
         ]
       : []),
   ],
+  // ビルド時に決まる Sentry のメタ情報をブラウザ側へ埋め込む。
+  // VITE_ 変数と違い Vercel での追加設定が要らない（VERCEL_* から導出する）。
+  define: {
+    __SENTRY_RELEASE__: JSON.stringify(sentryRelease),
+    __SENTRY_ENVIRONMENT__: JSON.stringify(sentryEnvironment),
+  },
   // ソースマップはアップロードする時だけ生成する。
   build: {
     sourcemap: uploadSourcemaps,


### PR DESCRIPTION
## 概要

Sentry のイベントに release（commit SHA）と environment（production / preview）が付くようにし、有効化手順を `docs/sentry-setup.md` に集約する。

Closes #52

DSN 登録・ソースマップのアップロードは本番で完了済み（エラー収集とスタックトレースの復元は動作確認できている）。このPRは**残っていた 2 つの取りこぼし**を直すもの。

- **イベントに release が付かない。** `Sentry.init` に `release: undefined` を明示的に渡していたため、`sentryVitePlugin` が注入した `__SENTRY_RELEASE__` を上書きしていた（SDK は `applyDefaultOptions` で `{ release: __SENTRY_RELEASE__, ...userOptions }` としており、キーが存在すれば `undefined` でも勝つ）。結果、Releases に artifacts はあるのにイベントと紐付かない
- **プレビューのエラーが本番と混ざる。** `environment` に `import.meta.env.MODE` を使っていたため、Preview デプロイも `production` として記録されていた

## 変更内容

- `vite.config.ts` の `define` で release / environment をバンドルへ埋め込み、`src/lib/sentry.ts` がそれを読むようにした。`VERCEL_GIT_COMMIT_SHA` / `VERCEL_ENV` から導出するので Vercel 側の追加設定は不要（`VITE_SENTRY_RELEASE` の手動登録が要らなくなる）
- `build.sourcemap` を `'hidden'` に変更。`.map` は作るが `sourceMappingURL` コメントを埋め込まないため、アップロード後に削除された `.map` を DevTools が取りに行って 404 になることが無くなる。突き合わせは debug ID なので復元には影響しない
- `deleteLeftoverSourcemaps` プラグインを追加。`filesToDeleteAfterUpload` は `./dist` 決め打ちなので、出力先を変えたときに `.map`（= 元コード）が残る。その保険
- `sentryVitePlugin` に `errorHandler` を追加し、アップロード失敗を読みやすい 1 行にした（既定でもビルドは通るので、挙動ではなくログの見やすさの変更）
- `src/vite-env.d.ts` を追加し、埋め込む定数と `VITE_` 変数に型を付けた
- `docs/sentry-setup.md` を追加（DSN 登録・再デプロイ・疎通確認・アラート通知・ソースマップ・トラブルシュート）。`CLAUDE.md` と `.env.example` からも参照

## 確認方法

```bash
npm run lint
npm run build
npm test
```

Vercel 相当の環境変数を与えたビルドで、バンドルの中身を実測して確認した。

```bash
# release / environment が埋め込まれること
VITE_SUPABASE_URL=... VITE_SUPABASE_ANON_KEY=... VITE_SENTRY_DSN=... \
  VERCEL_GIT_COMMIT_SHA=abc123def456 VERCEL_ENV=production npm run build
#   → release = "abc123def456" / environment = "production"

# DSN 未設定なら SDK の初期化ごと除去され no-op になること
VITE_SUPABASE_URL=... VITE_SUPABASE_ANON_KEY=... npm run build
#   → Sentry.init のコードがバンドルから消える

# アップロードが失敗しても .map が残らないこと（不正トークンで実行）
#   → 終了コード 0 / 残存 .map 0 件 / sourceMappingURL 0 件 / debug ID は 11 チャンクに注入済み
```

マージ後は **Vercel の再デプロイが必要**（`VITE_` 変数と `define` はビルド時にバンドルへ埋め込まれるため）。デプロイ後、Sentry の Issues でイベントに release（commit SHA）が付いていれば反映されている。

DB マイグレーションは含まないため `db push` は不要。

## スクリーンショット（UIの変更がある場合）

UI の変更なし。

## チェックリスト
- [x] `npm run lint` が通る
- [x] `npm run build` が通る
- [x] 動作確認済み（上記の実測。ログインが必要な画面の確認は含まない）
- [x] レビュアーを設定した

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pe8ztXo3Zfn4eWtCJea4Mt)_