### PR TITLE
feat(calendar): 個人予定の作成と外部カレンダー（.ics）の取り込みに対応

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ Schema defined in `supabase/migrations/0001_init.sql`. Key tables:
 | `team_messages` | Talk room messages; deleted after 30 days |
 | `friend_requests` | Friend requests awaiting approval |
 | `user_friends` | Bidirectional friendship pairs |
-| `events` | Calendar events scoped to team with `sharingState` |
+| `events` | Calendar events. `teamId` が NULL なら作成者だけの個人予定（`0020`）。外部カレンダーから取り込んだ行は `externalUid` を持つ |
 | `locations` | One row per user, updated in-place; Realtime enabled |
 
 `sharing_state` enum: `'private' | 'friends' | 'team'` — used in both `events` and `locations`.

--- a/src/components/Calendar/CalendarTab.tsx
+++ b/src/components/Calendar/CalendarTab.tsx
@@ -20,11 +20,20 @@ import {
   Spinner,
   Center,
 } from '@chakra-ui/react'
-import { ChevronLeftIcon, ChevronRightIcon, ChevronDownIcon, RepeatIcon, HamburgerIcon, AddIcon } from '@chakra-ui/icons'
+import {
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  ChevronDownIcon,
+  RepeatIcon,
+  HamburgerIcon,
+  AddIcon,
+  DownloadIcon,
+} from '@chakra-ui/icons'
 import { supabase } from '../../lib/supabase'
 import { useAuth } from '../../hooks/useAuth'
 import { Button } from '../ui/Button'
 import { EventModal } from './EventModal'
+import { ImportModal } from './ImportModal'
 import { TimeGridView } from './TimeGridView'
 import { MonthView } from './MonthView'
 import { CalendarSidebar, CalendarSidebarBody } from './CalendarSidebar'
@@ -32,6 +41,7 @@ import {
   EMPTY_FORM,
   eventToForm,
   eventsForRange,
+  formToEventValues,
   startOfWeek,
   startOfDay,
   addDays,
@@ -39,7 +49,6 @@ import {
   monthGridDays,
   toDateInput,
   minuteToTime,
-  viewerTimeZone,
   type CalendarView,
   type EventForm,
   type EventRow,
@@ -65,10 +74,12 @@ export default function CalendarTab() {
   const { isOpen, onOpen, onClose } = useDisclosure()
   // Mobile drawer that hosts the sidebar (create / mini-calendar / filters).
   const mobileNav = useDisclosure()
+  const importer = useDisclosure()
   const toast = useToast()
   const [form, setForm] = useState<EventForm>(EMPTY_FORM)
   // id of the event being edited; null when creating a new one
   const [editingId, setEditingId] = useState<string | null>(null)
+  const [saving, setSaving] = useState(false)
 
   function closeModal() {
     setEditingId(null)
@@ -76,6 +87,13 @@ export default function CalendarTab() {
   }
 
   const teamIds = useMemo(() => teams.map((t) => t.id), [teams])
+  // 新規作成の既定の保存先。チームに入っていなければ個人（null）。
+  const defaultTeamId = teams.length > 0 ? teams[0].id : null
+
+  // 新規作成用の空フォーム。
+  function blankForm(overrides?: Partial<EventForm>): EventForm {
+    return { ...EMPTY_FORM, teamId: defaultTeamId, ...overrides }
+  }
 
   // The date range currently visible, depending on the view.
   const [rangeStart, rangeEnd] = useMemo<[Date, Date]>(() => {
@@ -97,25 +115,26 @@ export default function CalendarTab() {
 
   // `silent` re-fetches without the full-grid spinner (used by the 更新 button).
   async function fetchEvents(opts?: { silent?: boolean }) {
-    if (!teamIds || teamIds.length === 0) return setEvents([])
+    if (!user) return setEvents([])
     if (opts?.silent) setRefreshing(true)
     else setLoading(true)
     try {
       // (1) Non-recurring events (and recurring masters) overlapping the range.
       // (2) Recurring masters that started before the range but recur into it.
       // Merge + de-dupe; occurrences are expanded client-side via eventsForRange.
+      //
+      // チームでの絞り込みはしない。RLS（events_select）が「自分の個人予定 ＋
+      // 所属チームの予定」だけを返すので、チーム未所属でも個人予定が見える。
       const [inRange, recurringMasters] = await Promise.all([
         supabase
           .from('events')
           .select('*')
-          .in('teamId', teamIds)
           .lt('startAt', rangeEnd.toISOString())
           .gt('endAt', rangeStart.toISOString())
           .order('startAt', { ascending: true }),
         supabase
           .from('events')
           .select('*')
-          .in('teamId', teamIds)
           .neq('recurrence', 'none')
           .lt('startAt', rangeEnd.toISOString()),
       ])
@@ -144,7 +163,10 @@ export default function CalendarTab() {
   const visibleEvents = useMemo(
     () =>
       eventsForRange(events, rangeStart, rangeEnd).filter(
-        (e) => filters.has(e.sharingState as SharingState) && !hiddenTeams.has(e.teamId),
+        (e) =>
+          filters.has(e.sharingState as SharingState) &&
+          // 個人予定（teamId なし）はチームの絞り込み対象外。
+          (e.teamId === null || !hiddenTeams.has(e.teamId)),
       ),
     [events, filters, hiddenTeams, rangeStart, rangeEnd],
   )
@@ -210,7 +232,7 @@ export default function CalendarTab() {
 
   function openBlank() {
     setEditingId(null)
-    setForm(EMPTY_FORM)
+    setForm(blankForm())
     onOpen()
   }
 
@@ -218,20 +240,21 @@ export default function CalendarTab() {
     const dateStr = toDateInput(day)
     const endMinute = minute + 60
     setEditingId(null)
-    setForm({
-      ...EMPTY_FORM,
-      startDate: dateStr,
-      startTime: minuteToTime(minute),
-      endDate: dateStr,
-      endTime: endMinute <= 24 * 60 ? minuteToTime(endMinute) : '',
-    })
+    setForm(
+      blankForm({
+        startDate: dateStr,
+        startTime: minuteToTime(minute),
+        endDate: dateStr,
+        endTime: endMinute <= 24 * 60 ? minuteToTime(endMinute) : '',
+      }),
+    )
     onOpen()
   }
 
   function openAllDay(day: Date) {
     const dateStr = toDateInput(day)
     setEditingId(null)
-    setForm({ ...EMPTY_FORM, isAllDay: true, startDate: dateStr, endDate: dateStr })
+    setForm(blankForm({ isAllDay: true, startDate: dateStr, endDate: dateStr }))
     onOpen()
   }
 
@@ -251,49 +274,19 @@ export default function CalendarTab() {
       toast({ status: 'error', title: 'ログインが必要です' })
       return
     }
-    if (!teams || teams.length === 0) {
-      toast({
-        status: 'warning',
-        title: 'チームに参加していません',
-        description: '予定を追加するにはチームへの参加が必要です。',
-      })
+
+    // チームに入っていなくても予定は作れる（teamId = null の個人予定になる）。
+    const result = formToEventValues(form)
+    if (!result.ok) {
+      toast({ status: 'error', title: result.error })
       return
     }
 
-    let start: Date
-    let end: Date
-    if (form.isAllDay) {
-      start = new Date(`${form.startDate}T00:00`)
-      const endBase = new Date(`${form.endDate || form.startDate}T00:00`)
-      end = new Date(endBase.getTime() + 24 * 60 * 60 * 1000)
-    } else {
-      start = new Date(`${form.startDate}T${form.startTime}`)
-      const endRaw = new Date(`${form.endDate || form.startDate}T${form.endTime}`)
-      end = isNaN(endRaw.getTime()) ? new Date(start.getTime() + 60 * 60 * 1000) : endRaw
-    }
-    if (isNaN(start.getTime()) || isNaN(end.getTime())) {
-      toast({ status: 'error', title: '日時が正しくありません' })
-      return
-    }
-
-    const values = {
-      name: form.name,
-      startAt: start.toISOString(),
-      endAt: end.toISOString(),
-      isAllDay: form.isAllDay,
-      eventLocation: form.eventLocation || null,
-      sharingState: form.sharingState as SharingState,
-      recurrence: form.recurrence,
-      recurrenceEndDate: form.recurrence !== 'none' && form.recurrenceEndDate ? form.recurrenceEndDate : null,
-      // 編集時は元のTZを引き継ぎ、新規・未設定なら閲覧者のTZを記録する。
-      // 終日予定の日付は保存側で常にローカル深夜＝このTZの深夜になるため、
-      // 表示は dayKeyInTZ により全閲覧者で同じ日付に揃う。
-      timezone: form.timezone ?? viewerTimeZone(),
-    }
-
+    setSaving(true)
     const { error } = editingId
-      ? await supabase.from('events').update(values).eq('id', editingId)
-      : await supabase.from('events').insert({ ...values, createdBy: user.id, teamId: teams[0].id })
+      ? await supabase.from('events').update(result.values).eq('id', editingId)
+      : await supabase.from('events').insert({ ...result.values, createdBy: user.id })
+    setSaving(false)
 
     if (error) {
       console.error('save event error', error)
@@ -307,7 +300,7 @@ export default function CalendarTab() {
       return
     }
 
-    setForm(EMPTY_FORM)
+    setForm(blankForm())
     closeModal()
     fetchEvents()
   }
@@ -375,6 +368,21 @@ export default function CalendarTab() {
           <HStack spacing={2}>
             <Button
               variant="secondary"
+              leftIcon={<DownloadIcon />}
+              onClick={importer.onOpen}
+              display={{ base: 'none', md: 'inline-flex' }}
+            >
+              取り込み
+            </Button>
+            <IconButton
+              aria-label="外部カレンダーから取り込む"
+              icon={<DownloadIcon />}
+              variant="secondary"
+              display={{ base: 'inline-flex', md: 'none' }}
+              onClick={importer.onOpen}
+            />
+            <Button
+              variant="secondary"
               leftIcon={<RepeatIcon />}
               onClick={handleRefresh}
               isLoading={refreshing}
@@ -435,6 +443,15 @@ export default function CalendarTab() {
         setForm={setForm}
         onSubmit={handleSubmit}
         isEditing={!!editingId}
+        teams={teams}
+        isSaving={saving}
+      />
+
+      <ImportModal
+        isOpen={importer.isOpen}
+        onClose={importer.onClose}
+        teams={teams}
+        onImported={() => fetchEvents()}
       />
 
       {/* Mobile: sidebar contents in a drawer */}

--- a/src/components/Calendar/EventModal.tsx
+++ b/src/components/Calendar/EventModal.tsx
@@ -21,6 +21,8 @@ import { Button } from '../ui/Button'
 import { Input } from '../ui/Input'
 import { SHARING, RECURRENCE_LABEL, TIME_OPTIONS, viewerTimeZone, type EventForm, type SharingState } from './calendarUtils'
 
+type ModalTeam = { id: string; teamName: string }
+
 interface EventModalProps {
   isOpen: boolean
   onClose: () => void
@@ -28,10 +30,25 @@ interface EventModalProps {
   setForm: (f: EventForm) => void
   onSubmit: () => void
   isEditing?: boolean
+  teams?: ModalTeam[]
+  isSaving?: boolean
 }
 
-export function EventModal({ isOpen, onClose, form, setForm, onSubmit, isEditing }: EventModalProps) {
+// 保存先の <option> の値。空文字は個人（teamId = null）。
+const PERSONAL_VALUE = ''
+
+export function EventModal({
+  isOpen,
+  onClose,
+  form,
+  setForm,
+  onSubmit,
+  isEditing,
+  teams = [],
+  isSaving,
+}: EventModalProps) {
   const sharing = SHARING[form.sharingState as SharingState] ?? SHARING.private
+  const isPersonal = form.teamId === null
   return (
     <Modal isOpen={isOpen} onClose={onClose} isCentered>
       <ModalOverlay bg="blackAlpha.500" backdropFilter="blur(2px)" />
@@ -124,6 +141,31 @@ export function EventModal({ isOpen, onClose, form, setForm, onSubmit, isEditing
               />
             </FormControl>
 
+            {teams.length > 0 && (
+              <FormControl>
+                <FormLabel>保存先</FormLabel>
+                <Select
+                  value={form.teamId ?? PERSONAL_VALUE}
+                  onChange={(e) => {
+                    const teamId = e.target.value === PERSONAL_VALUE ? null : e.target.value
+                    setForm({
+                      ...form,
+                      teamId,
+                      // 個人の予定はチームには出ないので、公開範囲もそろえる。
+                      sharingState: teamId === null ? 'private' : form.sharingState,
+                    })
+                  }}
+                >
+                  <option value={PERSONAL_VALUE}>個人（自分のカレンダー）</option>
+                  {teams.map((t) => (
+                    <option key={t.id} value={t.id}>
+                      {t.teamName}
+                    </option>
+                  ))}
+                </Select>
+              </FormControl>
+            )}
+
             <FormControl>
               <FormLabel>
                 公開範囲{' '}
@@ -133,12 +175,18 @@ export function EventModal({ isOpen, onClose, form, setForm, onSubmit, isEditing
               </FormLabel>
               <Select
                 value={form.sharingState}
+                isDisabled={isPersonal}
                 onChange={(e) => setForm({ ...form, sharingState: e.target.value })}
               >
                 <option value="private">自分のみ</option>
                 <option value="friends">友だち</option>
                 <option value="team">チーム</option>
               </Select>
+              {isPersonal && (
+                <Text fontSize="xs" color="gray.500" mt={1}>
+                  個人の予定は自分だけが見られます。
+                </Text>
+              )}
             </FormControl>
 
             <FormControl>
@@ -183,7 +231,9 @@ export function EventModal({ isOpen, onClose, form, setForm, onSubmit, isEditing
           <Button
             variant="signal"
             onClick={onSubmit}
-            isDisabled={!form.name || !form.startDate || (!form.isAllDay && !form.startTime)}
+            isLoading={isSaving}
+            loadingText={isEditing ? '保存中' : '作成中'}
+            isDisabled={!form.name.trim() || !form.startDate || (!form.isAllDay && !form.startTime)}
           >
             {isEditing ? '保存する' : '作成する'}
           </Button>

--- a/src/components/Calendar/ImportModal.tsx
+++ b/src/components/Calendar/ImportModal.tsx
@@ -1,0 +1,474 @@
+import { useRef, useState } from 'react'
+import {
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  ModalCloseButton,
+  FormControl,
+  FormLabel,
+  Select,
+  Checkbox,
+  Box,
+  HStack,
+  VStack,
+  Text,
+  Badge,
+  Alert,
+  AlertIcon,
+  Center,
+  Spinner,
+  Link,
+  useToast,
+} from '@chakra-ui/react'
+import { Button } from '../ui/Button'
+import { supabase } from '../../lib/supabase'
+import { useAuth } from '../../hooks/useAuth'
+import { parseIcs, type ParsedIcsEvent } from './icsImport'
+import { RECURRENCE_LABEL, WEEKDAYS, type SharingState } from './calendarUtils'
+
+type ImportTeam = { id: string; teamName: string }
+
+interface ImportModalProps {
+  isOpen: boolean
+  onClose: () => void
+  teams: ImportTeam[]
+  /** 取り込み後にカレンダーを再読み込みさせる */
+  onImported: () => void
+}
+
+// 一度に取り込める件数の上限。数年分の書き出しをそのまま投げ込まれても
+// プレビューと INSERT が破綻しないようにする。
+const MAX_IMPORT = 500
+// INSERT はまとめて送る（PostgREST のリクエストが大きくなりすぎない粒度）。
+const CHUNK_SIZE = 100
+const PERSONAL_VALUE = ''
+
+interface Candidate extends ParsedIcsEvent {
+  /** 一覧内で一意なキー（UID が無い .ics もあるので通し番号で振る） */
+  key: string
+  /** 同じ UID の予定が既にある */
+  duplicate: boolean
+}
+
+export function ImportModal({ isOpen, onClose, teams, onImported }: ImportModalProps) {
+  const { user } = useAuth()
+  const toast = useToast()
+  const fileInput = useRef<HTMLInputElement>(null)
+
+  const [sourceName, setSourceName] = useState<string | null>(null)
+  const [candidates, setCandidates] = useState<Candidate[] | null>(null)
+  const [selected, setSelected] = useState<Set<string>>(new Set())
+  const [truncated, setTruncated] = useState(0)
+  const [skipped, setSkipped] = useState(0)
+  // 既定は「個人」。取り込むのは自分の外部カレンダーなので、
+  // 明示的に選ばない限りチームには流さない。
+  const [teamId, setTeamId] = useState<string | null>(null)
+  const [sharingState, setSharingState] = useState<SharingState>('private')
+  const [reading, setReading] = useState(false)
+  const [importing, setImporting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [dragging, setDragging] = useState(false)
+
+  function reset() {
+    setSourceName(null)
+    setCandidates(null)
+    setSelected(new Set())
+    setTruncated(0)
+    setSkipped(0)
+    setError(null)
+    setDragging(false)
+  }
+
+  function handleClose() {
+    if (importing) return
+    reset()
+    onClose()
+  }
+
+  async function handleFile(file: File) {
+    reset()
+    setReading(true)
+    try {
+      const text = await file.text()
+      const result = parseIcs(text)
+
+      if (result.events.length === 0) {
+        setError(
+          result.skipped > 0
+            ? 'このファイルの予定は取り込める形式ではありませんでした。'
+            : 'このファイルに予定が見つかりませんでした。.ics ファイルを選んでください。',
+        )
+        return
+      }
+
+      // 多すぎる場合は「今」に近い予定を優先して残す。
+      let events = result.events
+      let cut = 0
+      if (events.length > MAX_IMPORT) {
+        const now = Date.now()
+        cut = events.length - MAX_IMPORT
+        events = [...events]
+          .sort(
+            (a, b) =>
+              Math.abs(new Date(a.startAt).getTime() - now) - Math.abs(new Date(b.startAt).getTime() - now),
+          )
+          .slice(0, MAX_IMPORT)
+      }
+      events = [...events].sort((a, b) => a.startAt.localeCompare(b.startAt))
+
+      const duplicates = await findAlreadyImported(events)
+      const list: Candidate[] = events.map((ev, i) => ({
+        ...ev,
+        key: String(i),
+        duplicate: ev.uid !== null && duplicates.has(ev.uid),
+      }))
+
+      setSourceName(result.calendarName || file.name)
+      setCandidates(list)
+      setTruncated(cut)
+      setSkipped(result.skipped)
+      // 取り込み済みのものは既定で外しておく。
+      setSelected(new Set(list.filter((c) => !c.duplicate).map((c) => c.key)))
+    } catch (e) {
+      console.error('ics parse error', e)
+      setError('ファイルを読み込めませんでした。')
+    } finally {
+      setReading(false)
+    }
+  }
+
+  /** 既に同じ UID で取り込んだ予定を引く（重複取り込みを避けるため）。 */
+  async function findAlreadyImported(events: ParsedIcsEvent[]): Promise<Set<string>> {
+    const uids = events.map((e) => e.uid).filter((u): u is string => !!u)
+    if (!user || uids.length === 0) return new Set()
+
+    const found = new Set<string>()
+    for (let i = 0; i < uids.length; i += CHUNK_SIZE) {
+      const { data, error: queryError } = await supabase
+        .from('events')
+        .select('externalUid')
+        .eq('createdBy', user.id)
+        .in('externalUid', uids.slice(i, i + CHUNK_SIZE))
+      if (queryError) {
+        // 重複判定に失敗しても取り込み自体は続けられる（全部「新規」扱い）。
+        console.error('duplicate lookup error', queryError)
+        return found
+      }
+      for (const row of data ?? []) {
+        if (row.externalUid) found.add(row.externalUid)
+      }
+    }
+    return found
+  }
+
+  function toggle(key: string) {
+    setSelected((prev) => {
+      const next = new Set(prev)
+      if (next.has(key)) next.delete(key)
+      else next.add(key)
+      return next
+    })
+  }
+
+  function toggleAll() {
+    if (!candidates) return
+    setSelected((prev) =>
+      prev.size === candidates.length ? new Set() : new Set(candidates.map((c) => c.key)),
+    )
+  }
+
+  async function handleImport() {
+    if (!user || !candidates) return
+    const targets = candidates.filter((c) => selected.has(c.key))
+    if (targets.length === 0) return
+
+    setImporting(true)
+    try {
+      const rows = targets.map((ev) => ({
+        createdBy: user.id,
+        teamId,
+        name: ev.name,
+        startAt: ev.startAt,
+        endAt: ev.endAt,
+        isAllDay: ev.isAllDay,
+        eventLocation: ev.eventLocation,
+        sharingState,
+        recurrence: ev.recurrence,
+        recurrenceEndDate: ev.recurrenceEndDate,
+        timezone: ev.timezone,
+        externalUid: ev.uid,
+        externalSource: sourceName,
+      }))
+
+      let inserted = 0
+      for (let i = 0; i < rows.length; i += CHUNK_SIZE) {
+        const { error: insertError } = await supabase.from('events').insert(rows.slice(i, i + CHUNK_SIZE))
+        if (insertError) {
+          console.error('import insert error', insertError)
+          toast({
+            status: 'error',
+            title: '取り込みに失敗しました',
+            description: `${inserted} 件を取り込んだところで止まりました: ${insertError.message}`,
+            duration: 9000,
+            isClosable: true,
+          })
+          if (inserted > 0) onImported()
+          return
+        }
+        inserted += Math.min(CHUNK_SIZE, rows.length - i)
+      }
+
+      toast({ status: 'success', title: `${inserted} 件の予定を取り込みました` })
+      onImported()
+      reset()
+      onClose()
+    } finally {
+      setImporting(false)
+    }
+  }
+
+  const droppedRecurrence = candidates?.filter((c) => c.recurrenceDropped).length ?? 0
+
+  return (
+    <Modal isOpen={isOpen} onClose={handleClose} isCentered size="lg" scrollBehavior="inside">
+      <ModalOverlay bg="blackAlpha.500" backdropFilter="blur(2px)" />
+      <ModalContent mx={4}>
+        <ModalHeader fontFamily="heading">外部カレンダーから取り込む</ModalHeader>
+        <ModalCloseButton borderRadius="full" />
+
+        <ModalBody>
+          <VStack spacing={4} align="stretch">
+            {/* ファイル選択（クリック or ドラッグ＆ドロップ） */}
+            <Box
+              as="button"
+              type="button"
+              onClick={() => fileInput.current?.click()}
+              onDragOver={(e: React.DragEvent) => {
+                e.preventDefault()
+                setDragging(true)
+              }}
+              onDragLeave={() => setDragging(false)}
+              onDrop={(e: React.DragEvent) => {
+                e.preventDefault()
+                setDragging(false)
+                const file = e.dataTransfer.files?.[0]
+                if (file) void handleFile(file)
+              }}
+              w="full"
+              py={6}
+              px={4}
+              borderRadius="xl"
+              border="2px dashed"
+              borderColor={dragging ? 'signal.400' : 'gray.200'}
+              bg={dragging ? 'signal.50' : 'paper-2'}
+              transition="all 0.15s"
+              _hover={{ borderColor: 'signal.300', bg: 'signal.50' }}
+            >
+              <Text fontSize="sm" fontWeight="600" color="gray.700">
+                .ics ファイルを選ぶ / ここにドロップ
+              </Text>
+              <Text fontSize="xs" color="gray.500" mt={1}>
+                Google カレンダー・Apple カレンダー・Outlook から書き出したファイル
+              </Text>
+            </Box>
+            <input
+              ref={fileInput}
+              type="file"
+              accept=".ics,.ical,text/calendar"
+              hidden
+              onChange={(e) => {
+                const file = e.target.files?.[0]
+                if (file) void handleFile(file)
+                // 同じファイルを選び直せるようにする。
+                e.target.value = ''
+              }}
+            />
+
+            <Text fontSize="xs" color="gray.500">
+              Google カレンダーなら「設定 → インポート/エクスポート → エクスポート」で .ics
+              を書き出せます。
+              <Link
+                href="https://support.google.com/calendar/answer/37111"
+                isExternal
+                color="primary.600"
+                ml={1}
+              >
+                書き出し方法
+              </Link>
+            </Text>
+
+            {reading && (
+              <Center py={6}>
+                <Spinner color="primary.500" thickness="3px" />
+              </Center>
+            )}
+
+            {error && (
+              <Alert status="error" borderRadius="lg" fontSize="sm">
+                <AlertIcon />
+                {error}
+              </Alert>
+            )}
+
+            {candidates && (
+              <>
+                {truncated > 0 && (
+                  <Alert status="warning" borderRadius="lg" fontSize="sm">
+                    <AlertIcon />
+                    予定が多いため、今日に近い {MAX_IMPORT} 件のみ表示しています（残り {truncated} 件）。
+                  </Alert>
+                )}
+                {skipped > 0 && (
+                  <Text fontSize="xs" color="gray.500">
+                    日時を読み取れない・中止済みの予定 {skipped} 件は除いています。
+                  </Text>
+                )}
+                {droppedRecurrence > 0 && (
+                  <Text fontSize="xs" color="gray.500">
+                    このアプリで表現できない繰り返し（隔週・毎年など）の {droppedRecurrence} 件は、
+                    単発の予定として取り込みます。
+                  </Text>
+                )}
+
+                {teams.length > 0 && (
+                  <FormControl>
+                    <FormLabel>保存先</FormLabel>
+                    <Select
+                      value={teamId ?? PERSONAL_VALUE}
+                      onChange={(e) => {
+                        const next = e.target.value === PERSONAL_VALUE ? null : e.target.value
+                        setTeamId(next)
+                        if (next === null) setSharingState('private')
+                      }}
+                    >
+                      <option value={PERSONAL_VALUE}>個人（自分のカレンダー）</option>
+                      {teams.map((t) => (
+                        <option key={t.id} value={t.id}>
+                          {t.teamName}
+                        </option>
+                      ))}
+                    </Select>
+                  </FormControl>
+                )}
+
+                <FormControl>
+                  <FormLabel>公開範囲</FormLabel>
+                  <Select
+                    value={sharingState}
+                    isDisabled={teamId === null}
+                    onChange={(e) => setSharingState(e.target.value as SharingState)}
+                  >
+                    <option value="private">自分のみ</option>
+                    <option value="friends">友だち</option>
+                    <option value="team">チーム</option>
+                  </Select>
+                  {teamId === null && (
+                    <Text fontSize="xs" color="gray.500" mt={1}>
+                      個人の予定は自分だけが見られます。
+                    </Text>
+                  )}
+                </FormControl>
+
+                <Box>
+                  <HStack justify="space-between" mb={2}>
+                    <Text fontSize="xs" fontWeight="bold" color="gray.500" letterSpacing="wide">
+                      取り込む予定（{selected.size}/{candidates.length}）
+                    </Text>
+                    <Button size="sm" variant="ghost" onClick={toggleAll}>
+                      {selected.size === candidates.length ? 'すべて外す' : 'すべて選ぶ'}
+                    </Button>
+                  </HStack>
+
+                  <VStack
+                    align="stretch"
+                    spacing={0}
+                    maxH="260px"
+                    overflowY="auto"
+                    border="1px solid"
+                    borderColor="gray.200"
+                    borderRadius="lg"
+                  >
+                    {candidates.map((c) => (
+                      <HStack
+                        key={c.key}
+                        align="start"
+                        spacing={3}
+                        px={3}
+                        py={2}
+                        borderBottom="1px solid"
+                        borderColor="gray.100"
+                        _last={{ borderBottom: 'none' }}
+                      >
+                        <Checkbox
+                          mt={1}
+                          colorScheme="primary"
+                          isChecked={selected.has(c.key)}
+                          onChange={() => toggle(c.key)}
+                        />
+                        <Box minW={0} flex={1}>
+                          <HStack spacing={2}>
+                            <Text fontSize="sm" fontWeight="600" color="gray.800" noOfLines={1}>
+                              {c.name}
+                            </Text>
+                            {c.duplicate && (
+                              <Badge colorScheme="gray" variant="subtle" flexShrink={0}>
+                                取込済み
+                              </Badge>
+                            )}
+                            {c.recurrence !== 'none' && (
+                              <Badge colorScheme="primary" variant="subtle" flexShrink={0}>
+                                {RECURRENCE_LABEL[c.recurrence]}
+                              </Badge>
+                            )}
+                          </HStack>
+                          <Text fontSize="xs" color="gray.500" noOfLines={1}>
+                            {describeRange(c)}
+                            {c.eventLocation ? ` ・ ${c.eventLocation}` : ''}
+                          </Text>
+                        </Box>
+                      </HStack>
+                    ))}
+                  </VStack>
+                </Box>
+              </>
+            )}
+          </VStack>
+        </ModalBody>
+
+        <ModalFooter gap={2}>
+          <Button variant="ghost" onClick={handleClose} isDisabled={importing}>
+            キャンセル
+          </Button>
+          <Button
+            variant="signal"
+            onClick={handleImport}
+            isLoading={importing}
+            loadingText="取り込み中"
+            isDisabled={!candidates || selected.size === 0}
+          >
+            {selected.size > 0 ? `${selected.size} 件を取り込む` : '取り込む'}
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  )
+}
+
+/** プレビュー用の日時表示。「8/14(金) 09:00–10:00」「8/14(金) 終日」 */
+function describeRange(ev: ParsedIcsEvent): string {
+  const start = new Date(ev.startAt)
+  const end = new Date(ev.endAt)
+  const day = `${start.getMonth() + 1}/${start.getDate()}(${WEEKDAYS[start.getDay()]})`
+  if (ev.isAllDay) {
+    const lastDay = new Date(end.getTime() - 24 * 60 * 60 * 1000)
+    const span =
+      lastDay.getTime() > start.getTime() ? `〜${lastDay.getMonth() + 1}/${lastDay.getDate()}` : ''
+    return `${day}${span} 終日`
+  }
+  const hm = (d: Date) =>
+    `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`
+  return `${day} ${hm(start)}–${hm(end)}`
+}

--- a/src/components/Calendar/calendarUtils.test.ts
+++ b/src/components/Calendar/calendarUtils.test.ts
@@ -12,7 +12,11 @@ import {
   monthGridDays,
   overlapsDay,
   eventToForm,
+  formToEventValues,
   layoutDay,
+  viewerTimeZone,
+  EMPTY_FORM,
+  type EventForm,
   type EventRow,
 } from './calendarUtils'
 
@@ -30,6 +34,8 @@ function makeEvent(overrides: Partial<EventRow> & { startAt: string; endAt: stri
     recurrence: overrides.recurrence ?? 'none',
     recurrenceEndDate: overrides.recurrenceEndDate ?? null,
     timezone: overrides.timezone ?? null,
+    externalUid: overrides.externalUid ?? null,
+    externalSource: overrides.externalSource ?? null,
     createdAt: overrides.createdAt ?? null,
     startAt: overrides.startAt,
     endAt: overrides.endAt,
@@ -185,5 +191,97 @@ describe('layoutDay', () => {
       makeEvent({ id: 'allday', isAllDay: true, startAt: new Date(2026, 5, 10, 0).toISOString(), endAt: new Date(2026, 5, 11, 0).toISOString() }),
     ]
     expect(layoutDay(day, events)).toHaveLength(0)
+  })
+})
+
+describe('formToEventValues', () => {
+  const base: EventForm = {
+    ...EMPTY_FORM,
+    name: '打ち合わせ',
+    startDate: '2026-06-10',
+    startTime: '09:00',
+    endDate: '2026-06-10',
+    endTime: '10:00',
+  }
+
+  function values(form: EventForm) {
+    const result = formToEventValues(form)
+    if (!result.ok) throw new Error(`expected ok, got: ${result.error}`)
+    return result.values
+  }
+
+  it('converts a timed event to local instants', () => {
+    const v = values(base)
+    expect(v.startAt).toBe(new Date(2026, 5, 10, 9).toISOString())
+    expect(v.endAt).toBe(new Date(2026, 5, 10, 10).toISOString())
+    expect(v.isAllDay).toBe(false)
+    expect(v.timezone).toBe(viewerTimeZone())
+  })
+
+  it('keeps a personal event teamId of null', () => {
+    expect(values(base).teamId).toBeNull()
+    expect(values({ ...base, teamId: 't1' }).teamId).toBe('t1')
+  })
+
+  it('stores an all-day event as midnight..next midnight (exclusive)', () => {
+    const v = values({ ...base, isAllDay: true, endDate: '2026-06-11' })
+    expect(v.startAt).toBe(new Date(2026, 5, 10).toISOString())
+    expect(v.endAt).toBe(new Date(2026, 5, 12).toISOString())
+  })
+
+  it('defaults an all-day event without an end date to a single day', () => {
+    const v = values({ ...base, isAllDay: true, endDate: '' })
+    expect(v.endAt).toBe(new Date(2026, 5, 11).toISOString())
+  })
+
+  it('defaults a missing end time to one hour', () => {
+    const v = values({ ...base, endTime: '' })
+    expect(v.endAt).toBe(new Date(2026, 5, 10, 10).toISOString())
+  })
+
+  it('keeps the original timezone when editing', () => {
+    expect(values({ ...base, timezone: 'America/New_York' }).timezone).toBe('America/New_York')
+  })
+
+  it('drops the recurrence end date when the event does not repeat', () => {
+    const v = values({ ...base, recurrence: 'none', recurrenceEndDate: '2026-07-01' })
+    expect(v.recurrenceEndDate).toBeNull()
+  })
+
+  it('keeps the recurrence end date for a repeating event', () => {
+    const v = values({ ...base, recurrence: 'weekly', recurrenceEndDate: '2026-07-01' })
+    expect(v.recurrenceEndDate).toBe('2026-07-01')
+  })
+
+  it('trims the title and turns a blank location into null', () => {
+    const v = values({ ...base, name: '  打ち合わせ  ', eventLocation: '   ' })
+    expect(v.name).toBe('打ち合わせ')
+    expect(v.eventLocation).toBeNull()
+  })
+
+  it('rejects an empty title', () => {
+    expect(formToEventValues({ ...base, name: '   ' })).toEqual({
+      ok: false,
+      error: 'タイトルを入力してください',
+    })
+  })
+
+  it('rejects a missing start date or time', () => {
+    expect(formToEventValues({ ...base, startDate: '' }).ok).toBe(false)
+    expect(formToEventValues({ ...base, startTime: '' }).ok).toBe(false)
+    // 終日なら開始時刻は要らない
+    expect(formToEventValues({ ...base, isAllDay: true, startTime: '' }).ok).toBe(true)
+  })
+
+  // DB の CHECK ("startAt" < "endAt") に当てて分かりにくいエラーを出さないよう、
+  // フォーム側で先に弾く。
+  it('rejects an end that is not after the start', () => {
+    const result = formToEventValues({ ...base, endTime: '09:00' })
+    expect(result).toEqual({ ok: false, error: '終了は開始より後にしてください' })
+  })
+
+  it('rejects an all-day end date before the start date', () => {
+    const result = formToEventValues({ ...base, isAllDay: true, endDate: '2026-06-09' })
+    expect(result).toEqual({ ok: false, error: '終了日は開始日以降にしてください' })
   })
 })

--- a/src/components/Calendar/calendarUtils.ts
+++ b/src/components/Calendar/calendarUtils.ts
@@ -175,6 +175,8 @@ export interface EventForm {
   sharingState: string
   recurrence: Recurrence
   recurrenceEndDate: string
+  // 予定の保存先。null はチームに属さない「個人の予定」。
+  teamId: string | null
   // 編集時に元予定のTZを引き継ぐ（新規作成時は undefined）。
   timezone?: string
 }
@@ -190,6 +192,7 @@ export const EMPTY_FORM: EventForm = {
   sharingState: 'private',
   recurrence: 'none',
   recurrenceEndDate: '',
+  teamId: null,
   timezone: undefined,
 }
 
@@ -221,6 +224,7 @@ export function eventToForm(ev: EventRow): EventForm {
       sharingState: ev.sharingState,
       recurrence: ev.recurrence ?? 'none',
       recurrenceEndDate: ev.recurrenceEndDate ?? '',
+      teamId: ev.teamId,
       timezone: ev.timezone,
     }
   }
@@ -237,7 +241,78 @@ export function eventToForm(ev: EventRow): EventForm {
     sharingState: ev.sharingState,
     recurrence: ev.recurrence ?? 'none',
     recurrenceEndDate: ev.recurrenceEndDate ?? '',
+    teamId: ev.teamId,
     timezone: ev.timezone ?? undefined,
+  }
+}
+
+// The columns an event insert/update writes. `createdBy` is added by the caller.
+export interface EventValues {
+  name: string
+  startAt: string
+  endAt: string
+  isAllDay: boolean
+  eventLocation: string | null
+  sharingState: SharingState
+  recurrence: Recurrence
+  recurrenceEndDate: string | null
+  teamId: string | null
+  timezone: string
+}
+
+export type EventFormResult = { ok: true; values: EventValues } | { ok: false; error: string }
+
+/**
+ * フォームの入力を events の行に変換する。日時が不正なまま送ると DB の
+ * CHECK ("startAt" < "endAt") で弾かれ、理由の分からないエラーになるため、
+ * ここで先に検証してメッセージを返す。
+ */
+export function formToEventValues(form: EventForm): EventFormResult {
+  const name = form.name.trim()
+  if (!name) return { ok: false, error: 'タイトルを入力してください' }
+  if (!form.startDate) return { ok: false, error: '開始日を入力してください' }
+  if (!form.isAllDay && !form.startTime) return { ok: false, error: '開始時刻を入力してください' }
+
+  let start: Date
+  let end: Date
+  if (form.isAllDay) {
+    start = new Date(`${form.startDate}T00:00`)
+    // 終日は「最終日の翌日 0:00」を排他的な終わりとして持つ。
+    end = addDays(new Date(`${form.endDate || form.startDate}T00:00`), 1)
+  } else {
+    start = new Date(`${form.startDate}T${form.startTime}`)
+    const endRaw = new Date(`${form.endDate || form.startDate}T${form.endTime}`)
+    // 終了未入力なら 1 時間の予定にする。
+    end = isNaN(endRaw.getTime()) ? new Date(start.getTime() + 60 * 60 * 1000) : endRaw
+  }
+
+  if (isNaN(start.getTime()) || isNaN(end.getTime())) {
+    return { ok: false, error: '日時が正しくありません' }
+  }
+  if (end <= start) {
+    return {
+      ok: false,
+      error: form.isAllDay ? '終了日は開始日以降にしてください' : '終了は開始より後にしてください',
+    }
+  }
+
+  return {
+    ok: true,
+    values: {
+      name,
+      startAt: start.toISOString(),
+      endAt: end.toISOString(),
+      isAllDay: form.isAllDay,
+      eventLocation: form.eventLocation.trim() || null,
+      sharingState: form.sharingState as SharingState,
+      recurrence: form.recurrence,
+      recurrenceEndDate: form.recurrence !== 'none' && form.recurrenceEndDate ? form.recurrenceEndDate : null,
+      teamId: form.teamId,
+      // 編集時は元のTZを引き継ぎ、新規・未設定なら閲覧者のTZを記録する。
+      // 終日予定の日付は保存側で常にローカル深夜＝このTZの深夜になるため、
+      // 表示は dayKeyInTZ により全閲覧者で同じ日付に揃う。
+      timezone: form.timezone ?? viewerTimeZone(),
+    },
   }
 }
 

--- a/src/components/Calendar/icsImport.test.ts
+++ b/src/components/Calendar/icsImport.test.ts
@@ -1,0 +1,282 @@
+import { describe, it, expect } from 'vitest'
+import { parseIcs, parseDuration, unescapeText, zonedTimeToUtc } from './icsImport'
+import { toDateInput } from './calendarUtils'
+
+// .ics は本来 CRLF 区切り。テストでも CRLF を使い、折り返し行の扱いも見る。
+function ics(...lines: string[]): string {
+  return ['BEGIN:VCALENDAR', 'VERSION:2.0', ...lines, 'END:VCALENDAR'].join('\r\n')
+}
+
+function vevent(...lines: string[]): string {
+  return ics('BEGIN:VEVENT', ...lines, 'END:VEVENT')
+}
+
+describe('unescapeText', () => {
+  it('restores escaped characters', () => {
+    expect(unescapeText('Lunch\\, then\\; talk\\nsee you')).toBe('Lunch, then; talk\nsee you')
+  })
+
+  it('keeps a literal backslash', () => {
+    expect(unescapeText('a\\\\b')).toBe('a\\b')
+  })
+})
+
+describe('parseDuration', () => {
+  it('parses hours and minutes', () => {
+    expect(parseDuration('PT1H30M')).toBe(90 * 60 * 1000)
+  })
+
+  it('parses days and weeks', () => {
+    expect(parseDuration('P1D')).toBe(24 * 60 * 60 * 1000)
+    expect(parseDuration('P2W')).toBe(14 * 24 * 60 * 60 * 1000)
+  })
+
+  it('rejects junk and zero-length durations', () => {
+    expect(parseDuration('1H')).toBeNull()
+    expect(parseDuration('P')).toBeNull()
+  })
+})
+
+describe('zonedTimeToUtc', () => {
+  it('converts a wall-clock time in a named zone', () => {
+    // 2026-08-14 09:00 Asia/Tokyo = 00:00 UTC
+    expect(zonedTimeToUtc(2026, 8, 14, 9, 0, 0, 'Asia/Tokyo').toISOString()).toBe(
+      '2026-08-14T00:00:00.000Z',
+    )
+  })
+
+  it('honours daylight saving time', () => {
+    // 夏時間中の New York は UTC-4
+    expect(zonedTimeToUtc(2026, 7, 1, 12, 0, 0, 'America/New_York').toISOString()).toBe(
+      '2026-07-01T16:00:00.000Z',
+    )
+    // 冬は UTC-5
+    expect(zonedTimeToUtc(2026, 1, 15, 12, 0, 0, 'America/New_York').toISOString()).toBe(
+      '2026-01-15T17:00:00.000Z',
+    )
+  })
+})
+
+describe('parseIcs', () => {
+  it('parses a UTC timed event', () => {
+    const result = parseIcs(
+      vevent(
+        'UID:abc-123',
+        'SUMMARY:チームランチ',
+        'LOCATION:渋谷',
+        'DTSTART:20260814T030000Z',
+        'DTEND:20260814T040000Z',
+      ),
+    )
+
+    expect(result.skipped).toBe(0)
+    expect(result.events).toHaveLength(1)
+    expect(result.events[0]).toMatchObject({
+      uid: 'abc-123',
+      name: 'チームランチ',
+      eventLocation: '渋谷',
+      startAt: '2026-08-14T03:00:00.000Z',
+      endAt: '2026-08-14T04:00:00.000Z',
+      isAllDay: false,
+      recurrence: 'none',
+    })
+  })
+
+  it('reads the calendar name from X-WR-CALNAME', () => {
+    const result = parseIcs(
+      ics('X-WR-CALNAME:私のカレンダー', 'BEGIN:VEVENT', 'DTSTART:20260814T030000Z', 'END:VEVENT'),
+    )
+    expect(result.calendarName).toBe('私のカレンダー')
+  })
+
+  it('converts TZID times to the right instant', () => {
+    const result = parseIcs(
+      vevent('DTSTART;TZID=Asia/Tokyo:20260814T090000', 'DTEND;TZID=Asia/Tokyo:20260814T100000'),
+    )
+    expect(result.events[0].startAt).toBe('2026-08-14T00:00:00.000Z')
+    expect(result.events[0].timezone).toBe('Asia/Tokyo')
+  })
+
+  it('falls back to local time for an unknown TZID', () => {
+    const result = parseIcs(
+      vevent('DTSTART;TZID=Tokyo Standard Time:20260814T090000', 'DURATION:PT1H'),
+      'Asia/Tokyo',
+    )
+    // 未知の TZID はローカル時刻として読む。ローカルの 9:00 になっていること。
+    expect(new Date(result.events[0].startAt).getHours()).toBe(9)
+    expect(result.events[0].timezone).toBe('Asia/Tokyo')
+  })
+
+  it('treats VALUE=DATE as an all-day event at local midnight', () => {
+    const result = parseIcs(
+      vevent('DTSTART;VALUE=DATE:20260814', 'DTEND;VALUE=DATE:20260816'),
+      'Asia/Tokyo',
+    )
+    const ev = result.events[0]
+    expect(ev.isAllDay).toBe(true)
+    expect(ev.timezone).toBe('Asia/Tokyo')
+    // 開始はローカル深夜、終了は排他的な 8/16 深夜（＝ 8/14, 8/15 の 2 日間）
+    expect(new Date(ev.startAt).getDate()).toBe(14)
+    expect(new Date(ev.startAt).getHours()).toBe(0)
+    expect(new Date(ev.endAt).getDate()).toBe(16)
+  })
+
+  it('gives an all-day event without DTEND a single day', () => {
+    const result = parseIcs(vevent('DTSTART;VALUE=DATE:20260814'))
+    const ev = result.events[0]
+    expect(ev.isAllDay).toBe(true)
+    expect(new Date(ev.endAt).getTime() - new Date(ev.startAt).getTime()).toBe(24 * 60 * 60 * 1000)
+  })
+
+  it('uses DURATION when DTEND is missing', () => {
+    const result = parseIcs(vevent('DTSTART:20260814T030000Z', 'DURATION:PT90M'))
+    expect(result.events[0].endAt).toBe('2026-08-14T04:30:00.000Z')
+  })
+
+  it('defaults to one hour when neither DTEND nor DURATION is present', () => {
+    const result = parseIcs(vevent('DTSTART:20260814T030000Z'))
+    expect(result.events[0].endAt).toBe('2026-08-14T04:00:00.000Z')
+  })
+
+  it('unfolds wrapped lines', () => {
+    const result = parseIcs(
+      vevent('DTSTART:20260814T030000Z', 'SUMMARY:とても長いタイトルの', ' 予定です', 'DTEND:20260814T040000Z'),
+    )
+    expect(result.events[0].name).toBe('とても長いタイトルの予定です')
+  })
+
+  it('falls back to a placeholder title', () => {
+    const result = parseIcs(vevent('DTSTART:20260814T030000Z'))
+    expect(result.events[0].name).toBe('（無題の予定）')
+  })
+
+  it('skips VALARM blocks inside an event', () => {
+    const result = parseIcs(
+      vevent(
+        'SUMMARY:本体',
+        'DTSTART:20260814T030000Z',
+        'BEGIN:VALARM',
+        'TRIGGER:-PT10M',
+        'SUMMARY:通知',
+        'END:VALARM',
+        'DTEND:20260814T040000Z',
+      ),
+    )
+    expect(result.events[0].name).toBe('本体')
+  })
+
+  it('ignores VTIMEZONE definitions', () => {
+    const result = parseIcs(
+      ics(
+        'BEGIN:VTIMEZONE',
+        'TZID:Asia/Tokyo',
+        'BEGIN:STANDARD',
+        'DTSTART:19700101T000000',
+        'TZOFFSETFROM:+0900',
+        'TZOFFSETTO:+0900',
+        'END:STANDARD',
+        'END:VTIMEZONE',
+        'BEGIN:VEVENT',
+        'SUMMARY:会議',
+        'DTSTART:20260814T030000Z',
+        'END:VEVENT',
+      ),
+    )
+    expect(result.events).toHaveLength(1)
+    expect(result.events[0].name).toBe('会議')
+  })
+
+  it('parses several events and counts unusable ones', () => {
+    const result = parseIcs(
+      ics(
+        'BEGIN:VEVENT',
+        'SUMMARY:あり',
+        'DTSTART:20260814T030000Z',
+        'END:VEVENT',
+        'BEGIN:VEVENT',
+        'SUMMARY:DTSTART なし',
+        'END:VEVENT',
+        'BEGIN:VEVENT',
+        'SUMMARY:中止',
+        'STATUS:CANCELLED',
+        'DTSTART:20260814T030000Z',
+        'END:VEVENT',
+      ),
+    )
+    expect(result.events).toHaveLength(1)
+    expect(result.skipped).toBe(2)
+  })
+
+  it('rejects an event whose end is not after its start', () => {
+    const result = parseIcs(vevent('DTSTART:20260814T040000Z', 'DTEND:20260814T030000Z'))
+    expect(result.events).toHaveLength(0)
+    expect(result.skipped).toBe(1)
+  })
+
+  describe('RRULE', () => {
+    it('maps simple frequencies', () => {
+      for (const [freq, expected] of [
+        ['DAILY', 'daily'],
+        ['WEEKLY', 'weekly'],
+        ['MONTHLY', 'monthly'],
+      ] as const) {
+        const result = parseIcs(vevent('DTSTART:20260814T030000Z', `RRULE:FREQ=${freq}`))
+        expect(result.events[0].recurrence).toBe(expected)
+        expect(result.events[0].recurrenceDropped).toBe(false)
+        expect(result.events[0].recurrenceEndDate).toBeNull()
+      }
+    })
+
+    it('keeps a single BYDAY on a weekly rule', () => {
+      const result = parseIcs(vevent('DTSTART:20260814T030000Z', 'RRULE:FREQ=WEEKLY;BYDAY=FR'))
+      expect(result.events[0].recurrence).toBe('weekly')
+    })
+
+    it('turns UNTIL into a recurrence end date', () => {
+      const result = parseIcs(
+        vevent('DTSTART:20260814T030000Z', 'RRULE:FREQ=WEEKLY;UNTIL=20260911T030000Z'),
+      )
+      // 繰り返しの終了日はアプリ側もローカル日付で解釈するので、UTC の UNTIL は
+      // 閲覧者のローカル暦日に落とす。
+      expect(result.events[0].recurrenceEndDate).toBe(toDateInput(new Date('2026-09-11T03:00:00Z')))
+    })
+
+    it('turns COUNT into a recurrence end date', () => {
+      // 8/14 から毎日 3 回 → 最終日は 8/16（ローカル時刻の DTSTART）
+      const result = parseIcs(vevent('DTSTART:20260814T030000', 'RRULE:FREQ=DAILY;COUNT=3'))
+      expect(result.events[0].recurrenceEndDate).toBe('2026-08-16')
+    })
+
+    it('drops rules it cannot represent', () => {
+      const unsupported = [
+        'FREQ=YEARLY',
+        'FREQ=WEEKLY;INTERVAL=2',
+        'FREQ=WEEKLY;BYDAY=MO,WE,FR',
+        'FREQ=MONTHLY;BYDAY=2MO',
+      ]
+      for (const rule of unsupported) {
+        const result = parseIcs(vevent('DTSTART:20260814T030000Z', `RRULE:${rule}`))
+        expect(result.events[0].recurrence).toBe('none')
+        expect(result.events[0].recurrenceDropped).toBe(true)
+      }
+    })
+  })
+
+  it('distinguishes a modified occurrence from its master by uid', () => {
+    const result = parseIcs(
+      ics(
+        'BEGIN:VEVENT',
+        'UID:series-1',
+        'DTSTART:20260814T030000Z',
+        'RRULE:FREQ=WEEKLY',
+        'END:VEVENT',
+        'BEGIN:VEVENT',
+        'UID:series-1',
+        'RECURRENCE-ID:20260821T030000Z',
+        'DTSTART:20260821T040000Z',
+        'END:VEVENT',
+      ),
+    )
+    expect(result.events.map((e) => e.uid)).toEqual(['series-1', 'series-1#20260821T030000Z'])
+  })
+})

--- a/src/components/Calendar/icsImport.ts
+++ b/src/components/Calendar/icsImport.ts
@@ -1,0 +1,396 @@
+// iCalendar (.ics / RFC 5545) parser — 外部カレンダーの取り込み用。
+//
+// Google カレンダー・Apple カレンダー・Outlook いずれも .ics でエクスポート
+// できるので、ファイルを読んで VEVENT を本アプリの events 行に落とし込む。
+// 対応範囲はアプリのデータモデルに合わせて絞ってある：
+//   - SUMMARY / LOCATION / DTSTART / DTEND / DURATION / UID / RRULE
+//   - 終日（VALUE=DATE）、TZID 付き、UTC（末尾 Z）、フローティング時刻
+//   - 繰り返しは INTERVAL=1 の DAILY / WEEKLY / MONTHLY のみ。表現できない
+//     ルール（毎年・隔週・BYDAY 複数など）は単発として取り込み、
+//     recurrenceDropped で呼び出し側に知らせる
+import {
+  addDays,
+  addMonths,
+  toDateInput,
+  viewerTimeZone,
+  type Recurrence,
+} from './calendarUtils'
+
+export interface ParsedIcsEvent {
+  /** .ics の UID（再取り込み時の重複判定に使う）。無ければ null */
+  uid: string | null
+  name: string
+  /** ISO 8601（UTC） */
+  startAt: string
+  endAt: string
+  isAllDay: boolean
+  eventLocation: string | null
+  recurrence: Recurrence
+  /** 'YYYY-MM-DD'。繰り返しの終わりが無ければ null */
+  recurrenceEndDate: string | null
+  timezone: string
+  /** RRULE があったが本アプリで表現できず、単発として取り込む場合 true */
+  recurrenceDropped: boolean
+}
+
+export interface IcsParseResult {
+  /** X-WR-CALNAME（Google などが入れるカレンダー名） */
+  calendarName: string | null
+  events: ParsedIcsEvent[]
+  /** DTSTART が無い・日時が壊れている等で取り込めなかった VEVENT の数 */
+  skipped: number
+}
+
+interface IcsLine {
+  name: string
+  params: Record<string, string>
+  value: string
+}
+
+interface IcsDate {
+  date: Date
+  /** VALUE=DATE（時刻を持たない＝終日） */
+  isDateOnly: boolean
+  timezone: string
+}
+
+const DATE_TIME_RE = /^(\d{4})(\d{2})(\d{2})(?:T(\d{2})(\d{2})(\d{2})(Z)?)?$/
+const DURATION_RE = /^([+-])?P(?:(\d+)W)?(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?$/
+
+/** 折り返された行（次行が空白・タブ始まり）を 1 本に戻す。 */
+function unfoldLines(text: string): string[] {
+  const out: string[] = []
+  for (const line of text.split(/\r\n|\n|\r/)) {
+    if (out.length > 0 && (line.startsWith(' ') || line.startsWith('\t'))) {
+      out[out.length - 1] += line.slice(1)
+    } else {
+      out.push(line)
+    }
+  }
+  return out
+}
+
+/** 引用符の外側にある区切り文字だけで分割する。 */
+function splitUnquoted(input: string, sep: string): string[] {
+  const parts: string[] = []
+  let current = ''
+  let inQuotes = false
+  for (const ch of input) {
+    if (ch === '"') inQuotes = !inQuotes
+    else if (ch === sep && !inQuotes) {
+      parts.push(current)
+      current = ''
+      continue
+    }
+    current += ch
+  }
+  parts.push(current)
+  return parts
+}
+
+/** "DTSTART;TZID=Asia/Tokyo:20260814T090000" → name / params / value */
+function parseLine(line: string): IcsLine | null {
+  let inQuotes = false
+  let colon = -1
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i]
+    if (ch === '"') inQuotes = !inQuotes
+    else if (ch === ':' && !inQuotes) {
+      colon = i
+      break
+    }
+  }
+  if (colon === -1) return null
+
+  const segments = splitUnquoted(line.slice(0, colon), ';')
+  const params: Record<string, string> = {}
+  for (const segment of segments.slice(1)) {
+    const eq = segment.indexOf('=')
+    if (eq === -1) continue
+    params[segment.slice(0, eq).toUpperCase()] = segment.slice(eq + 1).replace(/^"|"$/g, '')
+  }
+  return { name: segments[0].toUpperCase(), params, value: line.slice(colon + 1) }
+}
+
+/** TEXT 型のエスケープ（\n \, \; \\）を戻す。 */
+export function unescapeText(value: string): string {
+  return value.replace(/\\([\\;,nN])/g, (_, ch: string) =>
+    ch === 'n' || ch === 'N' ? '\n' : ch,
+  )
+}
+
+function isValidTimeZone(tz: string): boolean {
+  try {
+    new Intl.DateTimeFormat('en-US', { timeZone: tz })
+    return true
+  } catch {
+    return false
+  }
+}
+
+/** instant を tz で見たときの壁掛け時計の値と UTC との差（ミリ秒）。 */
+function timeZoneOffsetMs(instant: Date, tz: string): number {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: tz,
+    hour12: false,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  }).formatToParts(instant)
+  const get = (type: string) => Number(parts.find((p) => p.type === type)?.value ?? '0')
+  // hour12:false でも実装により深夜が "24" になることがある。
+  const asUtc = Date.UTC(get('year'), get('month') - 1, get('day'), get('hour') % 24, get('minute'), get('second'))
+  return asUtc - Math.floor(instant.getTime() / 1000) * 1000
+}
+
+/**
+ * 「そのタイムゾーンでの壁掛け時計の時刻」を実際の瞬間（UTC）に直す。
+ * オフセットは瞬間に依存する（夏時間）ため、推定 → 補正の 2 段で解く。
+ */
+export function zonedTimeToUtc(
+  y: number,
+  month: number,
+  day: number,
+  hour: number,
+  minute: number,
+  second: number,
+  tz: string,
+): Date {
+  const wall = Date.UTC(y, month - 1, day, hour, minute, second)
+  let instant = wall - timeZoneOffsetMs(new Date(wall), tz)
+  instant = wall - timeZoneOffsetMs(new Date(instant), tz)
+  return new Date(instant)
+}
+
+/**
+ * DTSTART / DTEND の値を解釈する。
+ * - VALUE=DATE（時刻なし）→ ローカルの深夜。アプリの終日予定と同じ持ち方
+ * - 末尾 Z → UTC
+ * - TZID 付き → その TZ の壁掛け時計として解釈
+ * - それ以外（フローティング）→ 閲覧者のローカル時刻
+ */
+function parseIcsDate(line: IcsLine, viewerTz: string): IcsDate | null {
+  const match = DATE_TIME_RE.exec(line.value.trim())
+  if (!match) return null
+
+  const [, y, mo, d, h, mi, s, utc] = match
+  const year = Number(y)
+  const month = Number(mo)
+  const day = Number(d)
+
+  const dateOnly = line.params.VALUE?.toUpperCase() === 'DATE' || h === undefined
+  if (dateOnly) {
+    // 終日はローカル深夜で保存する（アプリの終日予定と同じ表現）。
+    return { date: new Date(year, month - 1, day), isDateOnly: true, timezone: viewerTz }
+  }
+
+  const hour = Number(h)
+  const minute = Number(mi)
+  const second = Number(s)
+
+  if (utc) {
+    return {
+      date: new Date(Date.UTC(year, month - 1, day, hour, minute, second)),
+      isDateOnly: false,
+      timezone: viewerTz,
+    }
+  }
+
+  const tzid = line.params.TZID
+  if (tzid && isValidTimeZone(tzid)) {
+    return {
+      date: zonedTimeToUtc(year, month, day, hour, minute, second, tzid),
+      isDateOnly: false,
+      timezone: tzid,
+    }
+  }
+
+  // TZID が IANA 名でない（Outlook の "Tokyo Standard Time" など）場合も含め、
+  // 解釈できないものは閲覧者のローカル時刻として扱う。
+  return {
+    date: new Date(year, month - 1, day, hour, minute, second),
+    isDateOnly: false,
+    timezone: viewerTz,
+  }
+}
+
+/** "PT1H30M" → ミリ秒。解釈できなければ null。 */
+export function parseDuration(value: string): number | null {
+  const match = DURATION_RE.exec(value.trim())
+  if (!match) return null
+  const [, sign, w, d, h, mi, s] = match
+  const ms =
+    (Number(w ?? 0) * 7 * 24 * 60 * 60 + Number(d ?? 0) * 24 * 60 * 60 + Number(h ?? 0) * 60 * 60 + Number(mi ?? 0) * 60 + Number(s ?? 0)) *
+    1000
+  if (ms === 0) return null
+  return sign === '-' ? -ms : ms
+}
+
+interface RecurrenceResult {
+  recurrence: Recurrence
+  recurrenceEndDate: string | null
+  dropped: boolean
+}
+
+const DROPPED: RecurrenceResult = { recurrence: 'none', recurrenceEndDate: null, dropped: true }
+
+/**
+ * RRULE をアプリの recurrence（none/daily/weekly/monthly）に落とす。
+ * 表現できないルールは単発（dropped）にする。取りこぼしを黙って捨てるより、
+ * 呼び出し側で「繰り返しは取り込めません」と出すため。
+ */
+export function parseRRule(value: string, start: IcsDate): RecurrenceResult {
+  const rule: Record<string, string> = {}
+  for (const part of value.split(';')) {
+    const eq = part.indexOf('=')
+    if (eq === -1) continue
+    rule[part.slice(0, eq).toUpperCase()] = part.slice(eq + 1)
+  }
+
+  const freq = rule.FREQ?.toUpperCase()
+  const recurrence: Recurrence | null =
+    freq === 'DAILY' ? 'daily' : freq === 'WEEKLY' ? 'weekly' : freq === 'MONTHLY' ? 'monthly' : null
+  if (!recurrence) return DROPPED
+
+  // 隔週・隔月などの間隔は持てない。
+  if (rule.INTERVAL && Number(rule.INTERVAL) !== 1) return DROPPED
+  // 「毎週 月・水・金」「第 2 月曜」などは開始日からの単純な繰り返しにならない。
+  if (rule.BYDAY && (recurrence === 'monthly' || rule.BYDAY.includes(','))) return DROPPED
+  if (rule.BYSETPOS || rule.BYMONTH || (rule.BYMONTHDAY && rule.BYMONTHDAY.includes(','))) return DROPPED
+
+  if (rule.UNTIL) {
+    const until = parseLine(`UNTIL:${rule.UNTIL}`)
+    const parsed = until && parseIcsDate(until, start.timezone)
+    if (!parsed) return { recurrence, recurrenceEndDate: null, dropped: false }
+    return { recurrence, recurrenceEndDate: toDateInput(parsed.date), dropped: false }
+  }
+
+  if (rule.COUNT) {
+    const count = Number(rule.COUNT)
+    if (Number.isFinite(count) && count > 0) {
+      // COUNT 回目の開始日＝繰り返しの最終日。
+      let last = start.date
+      for (let i = 1; i < Math.min(count, 400); i++) {
+        last = recurrence === 'daily' ? addDays(last, 1) : recurrence === 'weekly' ? addDays(last, 7) : addMonths(last, 1)
+      }
+      return { recurrence, recurrenceEndDate: toDateInput(last), dropped: false }
+    }
+  }
+
+  return { recurrence, recurrenceEndDate: null, dropped: false }
+}
+
+/** .ics のテキストを解析して、取り込める予定の一覧を返す。 */
+export function parseIcs(text: string, viewerTz: string = viewerTimeZone()): IcsParseResult {
+  const lines = unfoldLines(text)
+
+  let calendarName: string | null = null
+  const events: ParsedIcsEvent[] = []
+  let skipped = 0
+
+  // 現在読んでいる VEVENT のプロパティ。VEVENT の外では null。
+  let current: Map<string, IcsLine> | null = null
+  // VEVENT の中の入れ子ブロック（VALARM など）は丸ごと読み飛ばす。
+  let nestedBlock: string | null = null
+
+  for (const raw of lines) {
+    const line = parseLine(raw)
+    if (!line) continue
+
+    if (line.name === 'BEGIN') {
+      const block = line.value.toUpperCase()
+      if (block === 'VEVENT') {
+        current = new Map()
+      } else if (current && !nestedBlock) {
+        nestedBlock = block
+      }
+      continue
+    }
+
+    if (line.name === 'END') {
+      const block = line.value.toUpperCase()
+      if (nestedBlock && block === nestedBlock) {
+        nestedBlock = null
+      } else if (block === 'VEVENT' && current) {
+        const parsed = toEvent(current, viewerTz)
+        if (parsed) events.push(parsed)
+        else skipped++
+        current = null
+      }
+      continue
+    }
+
+    if (nestedBlock) continue
+
+    if (current) {
+      // 同名プロパティは最初の 1 つを採用する（EXDATE などは未対応）。
+      if (!current.has(line.name)) current.set(line.name, line)
+    } else if (line.name === 'X-WR-CALNAME') {
+      calendarName = unescapeText(line.value).trim() || null
+    }
+  }
+
+  return { calendarName, events, skipped }
+}
+
+function toEvent(props: Map<string, IcsLine>, viewerTz: string): ParsedIcsEvent | null {
+  if (props.get('STATUS')?.value.toUpperCase() === 'CANCELLED') return null
+
+  const dtStartLine = props.get('DTSTART')
+  if (!dtStartLine) return null
+  const start = parseIcsDate(dtStartLine, viewerTz)
+  if (!start || isNaN(start.date.getTime())) return null
+
+  const end = resolveEnd(props, start)
+  if (!end || isNaN(end.getTime()) || end <= start.date) return null
+
+  const rruleLine = props.get('RRULE')
+  const rrule = rruleLine ? parseRRule(rruleLine.value, start) : null
+
+  const summary = props.get('SUMMARY')?.value ?? ''
+  const location = props.get('LOCATION')?.value ?? ''
+
+  return {
+    uid: buildUid(props),
+    name: unescapeText(summary).trim() || '（無題の予定）',
+    startAt: start.date.toISOString(),
+    endAt: end.toISOString(),
+    isAllDay: start.isDateOnly,
+    eventLocation: unescapeText(location).trim() || null,
+    recurrence: rrule?.recurrence ?? 'none',
+    recurrenceEndDate: rrule?.recurrenceEndDate ?? null,
+    timezone: start.timezone,
+    recurrenceDropped: rrule?.dropped ?? false,
+  }
+}
+
+/** DTEND、無ければ DURATION、それも無ければ既定の長さ（終日は 1 日、他は 1 時間）。 */
+function resolveEnd(props: Map<string, IcsLine>, start: IcsDate): Date | null {
+  const dtEndLine = props.get('DTEND')
+  if (dtEndLine) {
+    const end = parseIcsDate(dtEndLine, start.timezone)
+    if (end) return end.date
+  }
+
+  const durationLine = props.get('DURATION')
+  if (durationLine) {
+    const ms = parseDuration(durationLine.value)
+    if (ms !== null && ms > 0) return new Date(start.date.getTime() + ms)
+  }
+
+  return start.isDateOnly ? addDays(start.date, 1) : new Date(start.date.getTime() + 60 * 60 * 1000)
+}
+
+/**
+ * 重複判定のキー。繰り返しの一部だけ変更された予定（RECURRENCE-ID 付き）は
+ * マスターと UID が同じなので、別物として区別できるよう付け足す。
+ */
+function buildUid(props: Map<string, IcsLine>): string | null {
+  const uid = props.get('UID')?.value.trim()
+  if (!uid) return null
+  const recurrenceId = props.get('RECURRENCE-ID')?.value.trim()
+  return recurrenceId ? `${uid}#${recurrenceId}` : uid
+}

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -187,7 +187,7 @@ export type Database = {
         Row: {
           id: string
           createdBy: string
-          teamId: string
+          teamId: string | null
           name: string
           startAt: string
           endAt: string
@@ -197,12 +197,14 @@ export type Database = {
           recurrence: 'none' | 'daily' | 'weekly' | 'monthly'
           recurrenceEndDate: string | null
           timezone: string | null
+          externalUid: string | null
+          externalSource: string | null
           createdAt: string | null
         }
         Insert: {
           id?: string
           createdBy: string
-          teamId: string
+          teamId?: string | null
           name: string
           startAt: string
           endAt: string
@@ -212,12 +214,14 @@ export type Database = {
           recurrence?: 'none' | 'daily' | 'weekly' | 'monthly'
           recurrenceEndDate?: string | null
           timezone?: string | null
+          externalUid?: string | null
+          externalSource?: string | null
           createdAt?: string | null
         }
         Update: {
           id?: string
           createdBy?: string
-          teamId?: string
+          teamId?: string | null
           name?: string
           startAt?: string
           endAt?: string
@@ -227,6 +231,8 @@ export type Database = {
           recurrence?: 'none' | 'daily' | 'weekly' | 'monthly'
           recurrenceEndDate?: string | null
           timezone?: string | null
+          externalUid?: string | null
+          externalSource?: string | null
           createdAt?: string | null
         }
         Relationships: []

--- a/supabase/migrations/0020_personal_events_and_import.sql
+++ b/supabase/migrations/0020_personal_events_and_import.sql
@@ -1,0 +1,54 @@
+-- ============================================================
+-- 0020_personal_events_and_import.sql
+--
+-- 1) 個人予定（チームに属さない予定）を作れるようにする
+--    これまで events."teamId" は NOT NULL だったため、チームに参加して
+--    いないユーザーは予定を 1 件も追加できなかった。
+--
+-- 2) 外部カレンダー（.ics）からのインポート用に、取り込み元を記録する
+--    列を追加する。再インポート時の重複検出に使う。
+--
+-- どちらも「新しい経路を足すだけ」の追加変更で、既存のコード（常に
+-- "teamId" を送り、externalUid を知らない）はそのまま動く。
+-- docs/migration-deploy-runbook.md のとおり、適用はフロントエンドの
+-- デプロイ後に行うこと。
+-- ============================================================
+
+-- ---------- 1) 個人予定 ----------
+
+-- NULL = どのチームにも属さない、作成者だけの予定。
+ALTER TABLE events ALTER COLUMN "teamId" DROP NOT NULL;
+
+-- SELECT の条件を広げる（既存のチーム予定の見え方は変えない）。
+DROP POLICY IF EXISTS "events_select" ON events;
+
+CREATE POLICY "events_select" ON events
+  FOR SELECT USING (
+    -- 個人予定は作成者だけが見られる
+    ("teamId" IS NULL AND "createdBy" = auth.uid())
+    OR "teamId" IN (
+      SELECT "teamId" FROM user_teams WHERE "userId" = auth.uid()
+    )
+  );
+
+-- INSERT / UPDATE / DELETE は既存どおり "createdBy" = auth.uid() で、
+-- "teamId" が NULL でもそのまま通る（ポリシーの変更は不要）。
+
+-- 個人予定の一覧取得用。
+CREATE INDEX IF NOT EXISTS idx_events_personal
+  ON events ("createdBy")
+  WHERE "teamId" IS NULL;
+
+
+-- ---------- 2) 外部カレンダーのインポート ----------
+
+-- .ics の UID。同じ予定を二重に取り込まないための照合キー。
+ALTER TABLE events ADD COLUMN IF NOT EXISTS "externalUid" text;
+
+-- 取り込み元の識別子（.ics の X-WR-CALNAME やファイル名）。表示用。
+ALTER TABLE events ADD COLUMN IF NOT EXISTS "externalSource" text;
+
+-- 「この UID はもう取り込んだか」を作成者ごとに引く。
+CREATE INDEX IF NOT EXISTS idx_events_external_uid
+  ON events ("createdBy", "externalUid")
+  WHERE "externalUid" IS NOT NULL;


### PR DESCRIPTION
## 予定を追加できない問題

events."teamId" が NOT NULL だったため、チームに参加していないユーザーは
予定を 1 件も作れなかった（CalendarTab がチーム未所属を検出して
「チームに参加していません」で弾いていた）。予定の取得もチーム ID で
絞っていたため、カレンダーが常に空だった。

- マイグレーション 0020 で "teamId" を NULL 許容にし、events_select に 「個人予定は作成者だけが見られる」条件を足した（SELECT を広げるだけの 追加変更で、既存のチーム予定の見え方は変わらない）
- 予定の取得はチーム ID での絞り込みをやめ、RLS に任せる
- チームに入っている場合は保存先（個人／チーム）を選べるようにした。 既定は従来どおり最初のチーム
- 日時の検証を formToEventValues に切り出した。終了が開始より前のときに DB の CHECK で弾かれて理由の分からないエラーになっていたのを、 フォーム側で先に伝える

## 外部カレンダーの取り込み

Google カレンダー・Apple カレンダー・Outlook から書き出した .ics を
読み込んで、取り込む予定を選んで一括登録できるようにした。

- icsImport.ts: RFC 5545 のパーサ（折り返し行、TZID / UTC / 終日 / フローティング時刻、DURATION、RRULE、エスケープ、VALARM の読み飛ばし）。 表現できない繰り返し（隔週・毎年など）は単発として取り込み、その旨を 画面に出す
- ImportModal.tsx: ファイル選択とドラッグ＆ドロップ、プレビューと選択、 保存先・公開範囲の指定、100 件ずつの INSERT
- 取り込んだ予定は externalUid を持ち、同じファイルを読み直しても 「取込済み」として既定で選択から外れる

## デプロイ順

migration-deploy-runbook.md のとおり、このコードをデプロイしてから
`npx supabase db push` を実行すること。順番が逆になると、取り込み機能が
externalUid の無いテーブルへ INSERT しようとして失敗する。


Claude-Session: https://claude.ai/code/session_01Nx622X9ScddVBHczNCWF1r

## 概要
<!-- このPRで何をしたかを一言で書く -->

Closes #<!-- Issue番号 -->

## 変更内容
- 
- 

## 確認方法
```bash
# 動作確認の手順を書く
npm run dev
```

## スクリーンショット（UIの変更がある場合）
<!-- 変更前・変更後の画像を貼る -->

## チェックリスト
- [ ] `npm run lint` が通る
- [ ] `npm run build` が通る
- [ ] 動作確認済み
- [ ] レビュアーを設定した
