### PR TITLE
Improve mobile responsiveness with bottom nav and viewport fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,9 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- viewport-fit=cover: ホーム画面に追加したときフルスクリーン表示になるため、
+         ノッチ／ホームバーの下に潜る領域まで描画し、余白は env(safe-area-inset-*) で確保する -->
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="theme-color" content="#0f9384" />
     <meta name="description" content="Daily Share — 仲間と今いる場所とこれからの予定を分かち合う" />
 

--- a/index.html
+++ b/index.html
@@ -4,8 +4,18 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <!-- viewport-fit=cover: ホーム画面に追加したときフルスクリーン表示になるため、
-         ノッチ／ホームバーの下に潜る領域まで描画し、余白は env(safe-area-inset-*) で確保する -->
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+         ノッチ／ホームバーの下に潜る領域まで描画し、余白は env(safe-area-inset-*) で確保する
+
+         interactive-widget=resizes-content: ソフトキーボードでレイアウト
+         ビューポートを縮める。既定の resizes-visual だとキーボードが出ても
+         レイアウトは縮まないため、position: fixed の下部ナビが本文の上へ
+         押し上がって重なる（チャットの入力欄をタップすると踏む）。
+         100dvh を使っている箇所もキーボード分を差し引けるようになる。
+         非対応ブラウザは無視するだけなので副作用は無い。 -->
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover, interactive-widget=resizes-content"
+    />
     <meta name="theme-color" content="#0f9384" />
     <meta name="description" content="Daily Share — 仲間と今いる場所とこれからの予定を分かち合う" />
 

--- a/src/components/Account/AccountModal.tsx
+++ b/src/components/Account/AccountModal.tsx
@@ -96,9 +96,9 @@ export function AccountModal({ isOpen, onClose, initialTab = 0 }: AccountModalPr
   }
 
   return (
-    <Modal isOpen={isOpen} onClose={onClose} isCentered size="md">
+    <Modal isOpen={isOpen} onClose={onClose} isCentered size="md" scrollBehavior="inside">
       <ModalOverlay bg="blackAlpha.500" backdropFilter="blur(2px)" />
-      <ModalContent mx={4}>
+      <ModalContent mx={4} my={{ base: 4, md: 16 }}>
         <ModalHeader fontFamily="heading">アカウント</ModalHeader>
         <ModalCloseButton borderRadius="full" />
         <ModalBody>

--- a/src/components/Auth/ProfileSetupModal.tsx
+++ b/src/components/Auth/ProfileSetupModal.tsx
@@ -93,9 +93,10 @@ export function ProfileSetupModal({ isOpen, onComplete }: ProfileSetupModalProps
       closeOnOverlayClick={false}
       closeOnEsc={false}
       isCentered
+      scrollBehavior="inside"
     >
       <ModalOverlay />
-      <ModalContent mx={4}>
+      <ModalContent mx={4} my={{ base: 4, md: 16 }}>
         <ModalHeader>
           <Text fontSize="xl" fontWeight="medium">プロフィール設定</Text>
           <Text fontSize="sm" color="gray.500" fontWeight="normal" mt={1}>

--- a/src/components/Calendar/CalendarTab.tsx
+++ b/src/components/Calendar/CalendarTab.tsx
@@ -23,6 +23,7 @@ import {
 import { ChevronLeftIcon, ChevronRightIcon, ChevronDownIcon, RepeatIcon, HamburgerIcon, AddIcon } from '@chakra-ui/icons'
 import { supabase } from '../../lib/supabase'
 import { useAuth } from '../../hooks/useAuth'
+import { aboveMobileNav } from '../../theme/layout'
 import { Button } from '../ui/Button'
 import { EventModal } from './EventModal'
 import { TimeGridView } from './TimeGridView'
@@ -48,9 +49,18 @@ import {
 
 const VIEW_LABEL: Record<CalendarView, string> = { day: '日', week: '週', month: '月' }
 
+/**
+ * スマホの初期表示は日表示にする。週表示は 7 列で最低 760px 必要なので、
+ * 狭い画面では横スクロール前提になり最初の一目で予定が読めない。
+ */
+function defaultView(): CalendarView {
+  if (typeof window === 'undefined') return 'week'
+  return window.matchMedia('(max-width: 47.99em)').matches ? 'day' : 'week'
+}
+
 export default function CalendarTab() {
   const { user, teams } = useAuth()
-  const [view, setView] = useState<CalendarView>('week')
+  const [view, setView] = useState<CalendarView>(defaultView)
   const [anchor, setAnchor] = useState(() => startOfDay(new Date()))
   const [events, setEvents] = useState<EventRow[]>([])
   const [loading, setLoading] = useState(false)
@@ -336,15 +346,10 @@ export default function CalendarTab() {
       />
 
       <Box flex={1} minW={0}>
-        {/* Toolbar */}
-        <Flex
-          justify="space-between"
-          align={{ base: 'stretch', md: 'center' }}
-          direction={{ base: 'column', md: 'row' }}
-          gap={3}
-          mb={5}
-        >
-          <HStack spacing={3}>
+        {/* Toolbar。狭い画面では日付ラベルを折り返して独立した行に置く
+            （ボタンと同じ行に並べると「8月9日 – …」と省略されてしまう）。 */}
+        <Flex align="center" wrap="wrap" gap={2} rowGap={2} mb={{ base: 4, md: 5 }}>
+          <HStack spacing={{ base: 2, md: 3 }}>
             <IconButton
               aria-label="メニュー"
               icon={<HamburgerIcon boxSize={5} />}
@@ -364,26 +369,44 @@ export default function CalendarTab() {
               <Box w="1px" h={6} bg="gray.200" />
               <IconButton aria-label="次へ" icon={<ChevronRightIcon boxSize={5} />} variant="ghost" borderRadius={0} onClick={goNext} />
             </HStack>
-            <Button variant="secondary" onClick={goToday}>
+            <Button variant="secondary" onClick={goToday} px={{ base: 4, md: 6 }}>
               今日
             </Button>
-            <Heading size="md" letterSpacing="tight" noOfLines={1}>
-              {rangeLabel}
-            </Heading>
           </HStack>
 
-          <HStack spacing={2}>
+          <Heading
+            size="md"
+            letterSpacing="tight"
+            noOfLines={1}
+            order={{ base: 1, md: 0 }}
+            w={{ base: 'full', md: 'auto' }}
+            flex={{ md: 1 }}
+          >
+            {rangeLabel}
+          </Heading>
+
+          <HStack spacing={2} ml="auto">
             <Button
               variant="secondary"
+              aria-label="更新"
               leftIcon={<RepeatIcon />}
+              iconSpacing={{ base: 0, md: 2 }}
+              px={{ base: 4, md: 6 }}
               onClick={handleRefresh}
               isLoading={refreshing}
-              loadingText="更新中"
             >
-              更新
+              {/* 狭い画面はアイコンだけにして、日付ラベルへ幅を譲る */}
+              <Box as="span" display={{ base: 'none', md: 'inline' }}>
+                更新
+              </Box>
             </Button>
             <Menu>
-              <MenuButton as={Button} variant="secondary" rightIcon={<ChevronDownIcon />}>
+              <MenuButton
+                as={Button}
+                variant="secondary"
+                rightIcon={<ChevronDownIcon />}
+                px={{ base: 4, md: 6 }}
+              >
                 {VIEW_LABEL[view]}
               </MenuButton>
               <MenuList minW="120px">
@@ -472,9 +495,10 @@ export default function CalendarTab() {
         onClick={openBlank}
         display={{ base: 'inline-flex', lg: 'none' }}
         position="fixed"
-        bottom={6}
-        right={6}
-        zIndex={20}
+        // スマホでは画面下のナビに重ならない高さへ逃がす。
+        bottom={{ base: aboveMobileNav(), md: 6 }}
+        right={{ base: 4, md: 6 }}
+        zIndex={1050}
         boxSize={14}
         borderRadius="full"
         bg="signal.500"

--- a/src/components/Calendar/EventModal.tsx
+++ b/src/components/Calendar/EventModal.tsx
@@ -33,9 +33,11 @@ interface EventModalProps {
 export function EventModal({ isOpen, onClose, form, setForm, onSubmit, isEditing }: EventModalProps) {
   const sharing = SHARING[form.sharingState as SharingState] ?? SHARING.private
   return (
-    <Modal isOpen={isOpen} onClose={onClose} isCentered>
+    // scrollBehavior="inside": 項目が多いので、狭い画面ではダイアログを
+    // 画面内に収めて中身だけスクロールさせる
+    <Modal isOpen={isOpen} onClose={onClose} isCentered scrollBehavior="inside">
       <ModalOverlay bg="blackAlpha.500" backdropFilter="blur(2px)" />
-      <ModalContent mx={4}>
+      <ModalContent mx={4} my={{ base: 4, md: 16 }}>
         <ModalHeader fontFamily="heading">{isEditing ? '予定を編集' : '予定を追加'}</ModalHeader>
         <ModalCloseButton borderRadius="full" />
         <ModalBody>

--- a/src/components/Calendar/TimeGridView.tsx
+++ b/src/components/Calendar/TimeGridView.tsx
@@ -67,7 +67,9 @@ export function TimeGridView({
             ref={scrollRef}
             direction="column"
             overflowY="auto"
-            maxH={{ base: '74vh', md: 'calc(100dvh - 200px)' }}
+            // スマホはヘッダー・ツールバー・下部ナビの分を引いて、
+            // グリッドが画面内に収まるようにする（74vh だとはみ出す）。
+            maxH={{ base: 'calc(100svh - 280px)', md: 'calc(100dvh - 200px)' }}
           >
             {/* Sticky header: day labels + all-day row stay visible while scrolling */}
             <Box position="sticky" top={0} zIndex={4} bg="paper-2">

--- a/src/components/Chat/RoomMembersModal.tsx
+++ b/src/components/Chat/RoomMembersModal.tsx
@@ -197,7 +197,7 @@ export function RoomMembersModal({
     <>
       <Modal isOpen={isOpen} onClose={onClose} isCentered scrollBehavior="inside">
         <ModalOverlay bg="blackAlpha.500" backdropFilter="blur(2px)" />
-        <ModalContent mx={4}>
+        <ModalContent mx={4} my={{ base: 4, md: 16 }}>
           <ModalHeader fontFamily="heading">メンバー管理</ModalHeader>
           <ModalCloseButton borderRadius="full" />
           <ModalBody>

--- a/src/components/Chat/RoomView.tsx
+++ b/src/components/Chat/RoomView.tsx
@@ -13,6 +13,7 @@ import {
   useDisclosure,
 } from '@chakra-ui/react'
 import { avatarColor } from '../../lib/avatarColor'
+import { COMPACT_NAV_QUERY, MOBILE_NAV_HEIGHT } from '../../theme/layout'
 import { ArrowUpIcon, ArrowBackIcon } from '@chakra-ui/icons'
 import { supabase } from '../../lib/supabase'
 import { useTeamMembers } from '../../hooks/useTeamMembers'
@@ -195,10 +196,18 @@ export function RoomView({ team, currentUserId, onBack, onLeft }: RoomViewProps)
         ref={listRef}
         onScroll={handleScroll}
         // 100vh はアドレスバーの分だけ実際の表示領域より大きく、入力欄が
-        // 画面外へ押し出される。dvh で実寸に合わせ、スマホは下部ナビの
-        // 高さも差し引く。
+        // 画面外へ押し出される。dvh で実寸に合わせる。
         h="calc(100dvh - 300px)"
-        minH={{ base: '240px', md: '320px' }}
+        minH="320px"
+        // 下部ナビが出ている画面では、その高さも差し引かないと入力欄が
+        // ナビの下に潜る。minH も下げる（横向きスマホは画面高が 390px
+        // 程度しかなく、320px を確保すると入力欄が画面外へ出るため）。
+        sx={{
+          [COMPACT_NAV_QUERY]: {
+            height: `calc(100dvh - 300px - ${MOBILE_NAV_HEIGHT} - env(safe-area-inset-bottom))`,
+            minHeight: '160px',
+          },
+        }}
         overflowY="auto"
         px={3}
         py={4}

--- a/src/components/Chat/RoomView.tsx
+++ b/src/components/Chat/RoomView.tsx
@@ -194,8 +194,11 @@ export function RoomView({ team, currentUserId, onBack, onLeft }: RoomViewProps)
       <Box
         ref={listRef}
         onScroll={handleScroll}
-        h="calc(100vh - 300px)"
-        minH="320px"
+        // 100vh はアドレスバーの分だけ実際の表示領域より大きく、入力欄が
+        // 画面外へ押し出される。dvh で実寸に合わせ、スマホは下部ナビの
+        // 高さも差し引く。
+        h="calc(100dvh - 300px)"
+        minH={{ base: '240px', md: '320px' }}
         overflowY="auto"
         px={3}
         py={4}

--- a/src/components/Layout/MainLayout.tsx
+++ b/src/components/Layout/MainLayout.tsx
@@ -22,6 +22,7 @@ import {
   useDisclosure,
 } from '@chakra-ui/react'
 import { avatarColor } from '../../lib/avatarColor'
+import { MOBILE_NAV_HEIGHT, aboveMobileNav } from '../../theme/layout'
 import { useAuth } from '../../hooks/useAuth'
 import { useRedeemPendingInvite } from '../../hooks/usePendingInvite'
 import { Wordmark } from '../ui/Wordmark'
@@ -39,6 +40,14 @@ const TeamsTab = lazy(() => import('../Team/TeamsTab'))
 
 /** タブの並び順（カレンダー・地図・トーク・フレンド・チーム）における「トーク」。 */
 const TALK_TAB_INDEX = 2
+
+const TABS = [
+  { icon: '🗓', label: 'カレンダー' },
+  { icon: '🗺', label: 'マップ' },
+  { icon: '💬', label: 'チャット' },
+  { icon: '🤝', label: 'フレンド' },
+  { icon: '👥', label: 'チーム' },
+] as const
 
 function TabFallback() {
   return (
@@ -70,7 +79,7 @@ export function MainLayout() {
   }
 
   return (
-    <Box minH="100vh" bg="paper">
+    <Box minH="100svh" bg="paper">
       <Tabs
         index={tabIndex}
         onChange={(index) => setTabIndex(index)}
@@ -84,20 +93,24 @@ export function MainLayout() {
           borderColor="gray.200"
           position="sticky"
           top={0}
-          zIndex={10}
+          // Leaflet のコントロール（z-index 1000）より前に出す。
+          // Chakra のモーダル（1400）より後ろに保つこと。
+          zIndex={1100}
         >
           <Container maxW="6xl" px={{ base: 4, md: 6 }}>
-            <Flex align="center" justify="space-between" h={16} gap={4}>
-              <Wordmark size="sm" />
+            <Flex align="center" justify="space-between" h={16} gap={{ base: 2, md: 4 }}>
+              <Wordmark size="sm" flexShrink={0} />
 
-              <TabList gap={1} bg="gray.100" p={1} borderRadius="full">
-                {[
-                  { icon: '🗓', label: 'カレンダー' },
-                  { icon: '🗺', label: 'マップ' },
-                  { icon: '💬', label: 'チャット' },
-                  { icon: '🤝', label: 'フレンド' },
-                  { icon: '👥', label: 'チーム' },
-                ].map((t) => (
+              {/* タブ本体。スマホでは横幅に収まらないため隠し、画面下の
+                  ナビ（下部の <Flex as="nav">）から同じタブを切り替える。 */}
+              <TabList
+                gap={1}
+                bg="gray.100"
+                p={1}
+                borderRadius="full"
+                display={{ base: 'none', md: 'flex' }}
+              >
+                {TABS.map((t) => (
                   <Tab
                     key={t.label}
                     borderRadius="full"
@@ -112,7 +125,7 @@ export function MainLayout() {
                   >
                     <HStack spacing={1.5}>
                       <Box as="span">{t.icon}</Box>
-                      <Box as="span" display={{ base: 'none', sm: 'block' }}>
+                      <Box as="span" display={{ base: 'none', lg: 'block' }}>
                         {t.label}
                       </Box>
                     </HStack>
@@ -120,7 +133,7 @@ export function MainLayout() {
                 ))}
               </TabList>
 
-              <HStack spacing={1}>
+              <HStack spacing={1} flexShrink={0}>
               <NotificationBell userId={user?.id} />
               <Menu>
                 <MenuButton
@@ -167,7 +180,14 @@ export function MainLayout() {
           </Container>
         </Box>
 
-        <Container as="main" maxW="6xl" px={{ base: 4, md: 6 }} py={{ base: 5, md: 8 }}>
+        <Container
+          as="main"
+          maxW="6xl"
+          px={{ base: 3, md: 6 }}
+          pt={{ base: 4, md: 8 }}
+          // スマホは下部ナビの下に本文が潜り込まないよう、その分の余白を空ける。
+          pb={{ base: aboveMobileNav(), md: 8 }}
+        >
           <TabPanels>
             <TabPanel p={0}>
               <Suspense fallback={<TabFallback />}>
@@ -196,6 +216,57 @@ export function MainLayout() {
             </TabPanel>
           </TabPanels>
         </Container>
+
+        {/* スマホ用の下部ナビ。ヘッダーに 5 タブ＋ロゴ＋通知＋アカウントを
+            並べると 390px 幅に収まらず、ブラウザがページ全体を縮小して
+            レイアウトが崩れるため、狭い画面ではタブをここへ逃がす。 */}
+        <Flex
+          as="nav"
+          aria-label="メインナビゲーション"
+          display={{ base: 'flex', md: 'none' }}
+          position="fixed"
+          bottom={0}
+          left={0}
+          right={0}
+          // 地図タブでは Leaflet のコントロール（z-index 1000）が
+          // 重なってくるので、それより前に置く。
+          zIndex={1100}
+          bg="paper-2"
+          borderTop="1px solid"
+          borderColor="gray.200"
+          pb="env(safe-area-inset-bottom)"
+        >
+          {TABS.map((t, i) => {
+            const selected = tabIndex === i
+            return (
+              <Box
+                as="button"
+                type="button"
+                key={t.label}
+                flex={1}
+                minW={0}
+                h={MOBILE_NAV_HEIGHT}
+                onClick={() => setTabIndex(i)}
+                aria-current={selected ? 'page' : undefined}
+                color={selected ? 'primary.600' : 'gray.500'}
+                transition="color 0.15s"
+              >
+                <Box as="span" display="block" fontSize="lg" lineHeight="1.4">
+                  {t.icon}
+                </Box>
+                <Box
+                  as="span"
+                  display="block"
+                  fontSize="10px"
+                  fontWeight="semibold"
+                  letterSpacing="-0.02em"
+                >
+                  {t.label}
+                </Box>
+              </Box>
+            )
+          })}
+        </Flex>
       </Tabs>
 
       {account.isOpen && (

--- a/src/components/Layout/MainLayout.tsx
+++ b/src/components/Layout/MainLayout.tsx
@@ -22,7 +22,7 @@ import {
   useDisclosure,
 } from '@chakra-ui/react'
 import { avatarColor } from '../../lib/avatarColor'
-import { MOBILE_NAV_HEIGHT, aboveMobileNav } from '../../theme/layout'
+import { COMPACT_NAV_QUERY, MOBILE_NAV_HEIGHT, aboveMobileNav } from '../../theme/layout'
 import { useAuth } from '../../hooks/useAuth'
 import { useRedeemPendingInvite } from '../../hooks/usePendingInvite'
 import { Wordmark } from '../ui/Wordmark'
@@ -102,13 +102,15 @@ export function MainLayout() {
               <Wordmark size="sm" flexShrink={0} />
 
               {/* タブ本体。スマホでは横幅に収まらないため隠し、画面下の
-                  ナビ（下部の <Flex as="nav">）から同じタブを切り替える。 */}
+                  ナビ（下部の <Flex as="nav">）から同じタブを切り替える。
+                  横向きスマホもここに含める（COMPACT_NAV_QUERY 参照）。 */}
               <TabList
                 gap={1}
                 bg="gray.100"
                 p={1}
                 borderRadius="full"
-                display={{ base: 'none', md: 'flex' }}
+                display="flex"
+                sx={{ [COMPACT_NAV_QUERY]: { display: 'none' } }}
               >
                 {TABS.map((t) => (
                   <Tab
@@ -185,8 +187,10 @@ export function MainLayout() {
           maxW="6xl"
           px={{ base: 3, md: 6 }}
           pt={{ base: 4, md: 8 }}
-          // スマホは下部ナビの下に本文が潜り込まないよう、その分の余白を空ける。
-          pb={{ base: aboveMobileNav(), md: 8 }}
+          // 下部ナビの下に本文が潜り込まないよう、その分の余白を空ける。
+          // ナビの出し分けと同じ条件にすること（ずれると本文が隠れる）。
+          pb={8}
+          sx={{ [COMPACT_NAV_QUERY]: { paddingBottom: aboveMobileNav() } }}
         >
           <TabPanels>
             <TabPanel p={0}>
@@ -219,11 +223,13 @@ export function MainLayout() {
 
         {/* スマホ用の下部ナビ。ヘッダーに 5 タブ＋ロゴ＋通知＋アカウントを
             並べると 390px 幅に収まらず、ブラウザがページ全体を縮小して
-            レイアウトが崩れるため、狭い画面ではタブをここへ逃がす。 */}
+            レイアウトが崩れるため、狭い画面ではタブをここへ逃がす。
+            横向きスマホ（幅は広いが高さが低い）もこちらを使う。 */}
         <Flex
           as="nav"
           aria-label="メインナビゲーション"
-          display={{ base: 'flex', md: 'none' }}
+          display="none"
+          sx={{ [COMPACT_NAV_QUERY]: { display: 'flex' } }}
           position="fixed"
           bottom={0}
           left={0}

--- a/src/components/Legal/LegalModal.tsx
+++ b/src/components/Legal/LegalModal.tsx
@@ -93,7 +93,7 @@ export function LegalModal({ doc, onClose }: LegalModalProps) {
   return (
     <Modal isOpen={doc !== null} onClose={onClose} isCentered size="lg" scrollBehavior="inside">
       <ModalOverlay bg="blackAlpha.500" backdropFilter="blur(2px)" />
-      <ModalContent mx={4}>
+      <ModalContent mx={4} my={{ base: 4, md: 16 }}>
         <ModalHeader fontFamily="heading">
           {doc === 'terms' ? '利用規約' : 'プライバシーポリシー'}
         </ModalHeader>

--- a/src/components/Map/MapTab.tsx
+++ b/src/components/Map/MapTab.tsx
@@ -1,6 +1,6 @@
 import 'leaflet/dist/leaflet.css'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { MapContainer, TileLayer, Marker, Popup, useMap, useMapEvents } from 'react-leaflet'
+import { MapContainer, TileLayer, Marker, Popup, ZoomControl, useMap, useMapEvents } from 'react-leaflet'
 import {
   Box,
   Button,
@@ -370,13 +370,21 @@ export default function MapTab() {
     : '位置情報を待機中...'
 
   return (
-    <Box bg="white" p={6} borderRadius="lg" boxShadow="sm" minH="calc(100vh - 160px)">
-      <Flex direction={{ base: 'column', md: 'row' }} justify="space-between" gap={4} mb={6}>
-        <VStack align="flex-start" spacing={3} flex="1">
-          <Text fontSize="2xl" fontWeight="semibold">
+    <Box bg="white" p={{ base: 3, md: 6 }} borderRadius="lg" boxShadow="sm">
+      <Flex direction={{ base: 'column', md: 'row' }} justify="space-between" gap={4} mb={{ base: 4, md: 6 }}>
+        <VStack align="flex-start" spacing={{ base: 2, md: 3 }} flex="1">
+          {/* 見出しは下部ナビの「マップ」と重複するので、狭い画面では省いて
+              地図そのものを少しでも上に出す */}
+          <Text fontSize="2xl" fontWeight="semibold" display={{ base: 'none', md: 'block' }}>
             マップ
           </Text>
-          <Text color="gray.600">「ライブ共有」をオンにすると、現在地が自動で送信され続けます。手動で送りたいときは「マップを更新」を押してください。左上の検索から特定の人を探せます。</Text>
+          {/* 狭い画面では説明が長いと地図が画面外へ押し出されるため、要点だけにする */}
+          <Text color="gray.600" fontSize="sm" display={{ base: 'block', md: 'none' }}>
+            「ライブ共有」をオンにすると現在地が自動で送信されます。
+          </Text>
+          <Text color="gray.600" display={{ base: 'none', md: 'block' }}>
+            「ライブ共有」をオンにすると、現在地が自動で送信され続けます。手動で送りたいときは「マップを更新」を押してください。左上の検索から特定の人を探せます。
+          </Text>
           <HStack spacing={3} flexWrap="wrap">
             <Badge colorScheme={sharingState === 'private' ? 'gray' : sharingState === 'friends' ? 'blue' : 'purple'}>
               {sharingState}
@@ -398,8 +406,8 @@ export default function MapTab() {
                 </Badge>
               )}
             </HStack>
-            <Text>{currentPositionLabel}</Text>
-            <Text>{saving ? '保存中...' : lastSavedAt ? `最終更新: ${lastSavedAt}` : ''}</Text>
+            <Text fontSize={{ base: 'sm', md: 'md' }}>{currentPositionLabel}</Text>
+            <Text fontSize={{ base: 'sm', md: 'md' }}>{saving ? '保存中...' : lastSavedAt ? `最終更新: ${lastSavedAt}` : ''}</Text>
             <Button
               size="sm"
               colorScheme="blue"
@@ -412,7 +420,7 @@ export default function MapTab() {
           </HStack>
         </VStack>
 
-        <Box minW="220px">
+        <Box minW={{ base: 0, md: '220px' }}>
           <Text mb={2} fontWeight="medium">
             共有範囲
           </Text>
@@ -463,9 +471,20 @@ export default function MapTab() {
         </Alert>
       )}
 
-      <Box h="calc(100vh - 280px)" position="relative">
-        {/* Find people: search teammates/friends who are sharing their location */}
-        <Box position="absolute" top={2} left={2} zIndex={1000} w={{ base: '70%', sm: '280px' }}>
+      {/* 100vh はスマホのアドレスバー分だけ実際の表示領域より大きく、
+          地図の下端が画面外へはみ出す。svh / dvh で実寸に合わせる。 */}
+      <Box h={{ base: '60svh', md: 'calc(100dvh - 280px)' }} minH="300px" position="relative">
+        {/* Find people: search teammates/friends who are sharing their location.
+            スマホでは地図の上端いっぱいに広げ、地図種別の切り替えとは
+            重ならないようにする（切り替えは下に逃がしてある）。 */}
+        <Box
+          position="absolute"
+          top={2}
+          left={2}
+          right={{ base: 2, sm: 'auto' }}
+          zIndex={1000}
+          w={{ base: 'auto', sm: '280px' }}
+        >
           <InputGroup bg="white" borderRadius="md" boxShadow="md">
             <InputLeftElement pointerEvents="none" color="gray.400">
               🔍
@@ -514,10 +533,13 @@ export default function MapTab() {
             </List>
           )}
         </Box>
+        {/* 地図種別の切り替え。スマホでは上に置くと検索欄と重なるため下へ。 */}
         <HStack
           position="absolute"
-          top={2}
-          right={2}
+          top={{ base: 'auto', sm: 2 }}
+          bottom={{ base: 2, sm: 'auto' }}
+          left={{ base: 2, sm: 'auto' }}
+          right={{ base: 'auto', sm: 2 }}
           zIndex={1000}
           bg="white"
           borderRadius="md"
@@ -541,8 +563,11 @@ export default function MapTab() {
           center={currentPosition ? [currentPosition.lat, currentPosition.lng] : [35.6762, 139.6503]}
           zoom={DEFAULT_ZOOM}
           doubleClickZoom={false}
+          // 既定の位置（左上）だと検索欄と重なるため、右下へ移す。
+          zoomControl={false}
           style={{ height: '100%', width: '100%' }}
         >
+          <ZoomControl position="bottomright" />
           <TileLayer
             attribution={TILE_LAYERS[tileLayer].attribution}
             url={TILE_LAYERS[tileLayer].url}

--- a/src/index.css
+++ b/src/index.css
@@ -14,6 +14,8 @@
 
   color-scheme: light;
   font-synthesis: none;
+  /* iOS の横向きで文字だけ勝手に拡大されるのを止める */
+  -webkit-text-size-adjust: 100%;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -27,6 +29,12 @@ html,
 body {
   margin: 0;
   padding: 0;
+  /* 幅からはみ出す要素があっても、スマホのブラウザがページ全体を縮小
+     （shrink-to-fit）してレイアウトごとずらしてしまわないようにする。
+     はみ出し自体は各コンポーネント側で出さないのが前提の保険。
+     hidden ではなく clip を使う。hidden はスクロールコンテナを作ってしまい、
+     ヘッダーの position: sticky が効かなくなる。 */
+  overflow-x: clip;
 }
 
 body {

--- a/src/theme/layout.ts
+++ b/src/theme/layout.ts
@@ -1,0 +1,11 @@
+/**
+ * スマホ表示（md 未満）で画面下に固定するナビゲーションの高さ。
+ * セーフエリア（ホームバー）分は含まないので、下端に固定する要素は
+ * `calc(${MOBILE_NAV_HEIGHT} + env(safe-area-inset-bottom) + 余白)` で逃がす。
+ */
+export const MOBILE_NAV_HEIGHT = '3.75rem'
+
+/** 画面下に固定する要素を、下部ナビの上へ逃がすための bottom 値。 */
+export function aboveMobileNav(gap = '1rem') {
+  return `calc(${MOBILE_NAV_HEIGHT} + env(safe-area-inset-bottom) + ${gap})`
+}

--- a/src/theme/layout.ts
+++ b/src/theme/layout.ts
@@ -9,3 +9,20 @@ export const MOBILE_NAV_HEIGHT = '3.75rem'
 export function aboveMobileNav(gap = '1rem') {
   return `calc(${MOBILE_NAV_HEIGHT} + env(safe-area-inset-bottom) + ${gap})`
 }
+
+/**
+ * 下部ナビを使う条件。
+ *
+ * 幅だけで判定すると**横向きのスマホで破綻する**。iPhone を横にすると
+ * 844x390 のように「幅は md(48em=768px) を超えるが高さは 390px しかない」
+ * 状態になり、下部ナビが消えてタブがヘッダー（画面の上）へ移動する。
+ * 65px のヘッダーが画面高の 17% を占め、親指も届かない。
+ *
+ * そのため高さの条件を or で足し、低い画面では幅が広くても下部ナビを使う。
+ * 30em(480px) は横向きスマホ（〜430px）を拾い、タブレット縦（1024px）や
+ * 横向きタブレット（〜600px以上）は拾わない値。
+ *
+ * Chakra のレスポンシブ配列は幅しか見られないため、生のメディアクエリを
+ * `sx` に渡して使う。
+ */
+export const COMPACT_NAV_QUERY = '@media (max-width: 47.9375em), (max-height: 29.9375em)'


### PR DESCRIPTION
## 概要

スマートフォン表示の使いやすさを大幅に改善。画面下に固定ナビゲーションを追加し、ヘッダーのタブをモバイルで非表示にして画面領域を有効活用。あわせてビューポート設定やユニット（`vh` → `svh`/`dvh`）を修正し、アドレスバーやホームバーの影響を排除。

Closes #<!-- Issue番号 -->

## 変更内容

### レイアウト基盤
- **新規ファイル `src/theme/layout.ts`** — モバイルナビの高さ定数と、セーフエリア対応の `aboveMobileNav()` ヘルパ関数を定義
- **`index.html`** — `viewport-fit=cover` を追加し、ノッチ/ホームバーの下の領域まで描画。セーフエリアは `env(safe-area-inset-*)` で確保
- **`src/index.css`** — `-webkit-text-size-adjust: 100%` で iOS 横向きの自動拡大を防止。`overflow-x: clip` でブラウザの shrink-to-fit を抑止

### メインレイアウト (`MainLayout.tsx`)
- **タブ定義の抽出** — `TABS` 配列を定数化し、ヘッダーとモバイルナビで共有
- **ヘッダーのタブ非表示** — `display={{ base: 'none', md: 'flex' }}` でモバイルではタブを隠す
- **モバイルナビ追加** — 画面下に固定される `<Flex as="nav">` で、タブと同じ機能を提供。セーフエリア対応
- **z-index 調整** — ヘッダーを 1100 に上げ、Leaflet コントロール（1000）より前、Chakra モーダル（1400）より後ろに配置
- **高さ修正** — `minH="100vh"` → `minH="100svh"` でアドレスバーの影響を排除
- **余白調整** — メインコンテナの `pb` にモバイルナビ分を加算

### カレンダータブ (`CalendarTab.tsx`)
- **初期表示の最適化** — `defaultView()` 関数で、狭い画面は日表示、広い画面は週表示に自動切り替え
- **ツールバーレイアウト** — 日付ラベルを独立した行に配置し、狭い画面での省略を防止
- **ボタン最適化** — 「更新」ボタンはモバイルではアイコンのみ表示
- **FAB 位置調整** — `bottom: aboveMobileNav()` でモバイルナビに重ならないよう逃がす
- **高さ修正** — `100vh` → `100svh` / `100dvh` でビューポート実寸に合わせ

### マップタブ (`MapTab.tsx`)
- **説明文の簡潔化** — モバイルでは要点のみ表示し、地図領域を確保
- **見出し非表示** — モバイルでは「マップ」見出しを隠す
- **地図高さ修正** — `100vh` → `60svh` / `100dvh` で実寸対応
- **検索欄レイアウト**

https://claude.ai/code/session_01M7UN1UGZJkfxfBRV7uFj4b