### PR TITLE
fix: private の予定がチームメンバー全員に見えている問題を修正 (#107)

### DIFF
--- a/supabase/migrations/0021_fix_events_select_sharing_state.sql
+++ b/supabase/migrations/0021_fix_events_select_sharing_state.sql
@@ -1,0 +1,68 @@
+-- ============================================================
+-- 0021_fix_events_select_sharing_state.sql
+-- events_select が "sharingState" を見ていない問題を修正する（#107 / セキュリティ）
+--
+-- 症状:
+--   同じチームに属してさえいれば、他人が private で作った予定まで
+--   読めてしまう。0001 の events_select は teamId しか見ていない。
+--
+--     CREATE POLICY "events_select" ON events
+--       FOR SELECT USING (
+--         "teamId" IN (SELECT "teamId" FROM user_teams WHERE "userId" = auth.uid())
+--       );
+--
+--   CalendarTab の公開範囲フィルタ（private / friends / team のチップ）は
+--   取得済みの行を絞る**表示用**のもので、初期値は3つとも ON。
+--   つまり既定の状態で他人の private な予定が画面に出ている。
+--   フィルタで private を外しても、行はブラウザまで届いている。
+--
+--   locations_select は 0013 / 0019 で sharingState を見るよう直されたが、
+--   events_select は 0001 のまま一度も更新されていなかった。
+--
+-- 修正後の可視範囲:
+--   - 自分が作った予定       … 公開範囲に関係なく見える
+--   - 他人の private        … 見えない（本修正の主眼）
+--   - 他人の friends        … 同じチーム かつ 自分がフレンド登録している相手のみ
+--   - 他人の team           … 同じチームのメンバーなら見える（従来どおり）
+--
+-- 安全性:
+--   可視範囲を**狭めるだけ**で、新たに見えるようになる行は無い。
+--   デプロイ済みのフロントは events を
+--   `.select('*').in('teamId', teamIds)` で読むだけなので、
+--   返る行が減ってもエラーにはならず、他人の private が消えるという
+--   本来の挙動になる。よってコード側の変更は不要で、
+--   runbook の「3段階に分ける」対象（古いコードが動かなくなる変更）には
+--   当たらない。events を読むのは CalendarTab のみ（grep 済み）。
+--
+--   ポリシー式から参照する user_teams / user_friends は、どちらも
+--   "userId" = auth.uid() すなわち**自分の行**しか読まないため、
+--   0019 の回帰2（他人の行が RLS で見えず EXISTS が成立しない）は起きない。
+--   SECURITY DEFINER のヘルパは不要。
+-- ============================================================
+
+DROP POLICY IF EXISTS "events_select" ON events;
+
+CREATE POLICY "events_select" ON events
+  FOR SELECT USING (
+    -- 自分が作った予定は公開範囲を問わず見える
+    "createdBy" = auth.uid()
+    OR (
+      -- 他人の予定は「同じチームに属していること」が大前提
+      "teamId" IN (
+        SELECT "teamId" FROM user_teams WHERE "userId" = auth.uid()
+      )
+      AND (
+        "sharingState" = 'team'
+        OR (
+          -- 自分がフレンドとして登録している相手の予定のみ。
+          -- user_friends は双方向に行を持つ（0005）。
+          "sharingState" = 'friends'
+          AND "createdBy" IN (
+            SELECT "friendId" FROM user_friends WHERE "userId" = auth.uid()
+          )
+        )
+      )
+      -- "sharingState" = 'private' はどちらの分岐にも該当しないため、
+      -- 作成者以外には返らない。
+    )
+  );


### PR DESCRIPTION
## 概要

`events_select` が `sharingState` を見ておらず、**同じチームに属してさえいれば他人が `private` で作った予定まで読めていた**問題を修正します。(#107)

`locations_select` は `0013` / `0019` で `sharingState` を見るよう直されましたが、`events_select` は `0001` のまま一度も更新されていませんでした。

```sql
-- 0001 の定義。teamId しか見ていない
CREATE POLICY "events_select" ON events
  FOR SELECT USING (
    "teamId" IN (SELECT "teamId" FROM user_teams WHERE "userId" = auth.uid())
  );
```

`CalendarTab` の公開範囲フィルタ（private / friends / team のチップ）は**取得済みの行を絞る表示用**のもので、初期値は3つとも ON です。つまり既定の状態で他人の private な予定が画面に出ていました。フィルタで private を外しても、行自体はブラウザまで届いています。

## 修正後の可視範囲

| 対象 | 修正後 |
|---|---|
| 自分が作った予定 | 公開範囲に関係なく見える |
| 他人の `private` | **見えない**（本修正の主眼） |
| 他人の `friends` | 同じチーム かつ 自分がフレンド登録している相手のみ |
| 他人の `team` | 同じチームのメンバーなら見える（従来どおり） |

## 安全性

- **可視範囲を狭めるだけ**で、新たに見えるようになる行はありません
- `events` を読むのは `CalendarTab` のみ（grep で確認済み）。`.select('*').in('teamId', teamIds)` で読むだけなので、返る行が減ってもエラーにはなりません
- そのため**コード側の変更は不要**で、runbook の「3段階に分ける」対象（古いコードが動かなくなる変更）には当たりません
- ポリシー式から参照する `user_teams` / `user_friends` はどちらも `"userId" = auth.uid()` すなわち**自分の行**しか読まないため、`0019` の回帰2（他人の行が RLS で見えず EXISTS が成立しない）は起きません。`SECURITY DEFINER` のヘルパは不要です

## 検証状況

⚠️ **SQL の実行検証はできていません。** このマシンには Docker も psql も無く、ローカル Supabase を起動できないためです。デスクチェックのみです。適用前にレビューをお願いします。

- [x] `npm run lint` が通る
- [x] `npm run build` が通る
- [x] `npm test` が通る（80件）
- [ ] 動作確認済み ← ログインが必要なため未実施

## 適用手順

**runbook の鉄則どおり、本番への `db push` はこの PR がマージ・デプロイされた後に行ってください。** 今回はコード変更を伴わないため食い違いは起きにくいですが、順序は守る想定です。

## 別途対応が必要な問題

同じポリシーブロックに**書き込み側の穴**が残っています（本 PR には含めていません）。

- `events_insert` は `WITH CHECK ("createdBy" = auth.uid())` のみで、**target の `teamId` に所属しているか検査していない**。所属していないチームに予定を挿入できます
- `events_update` は `USING` だけで `WITH CHECK` が無いため、自分の予定の `teamId` を**任意のチームに書き換えられます**

読み取り側（本 PR）とは壊れ方のリスクが違う（書き込みの厳格化は過去に本番を壊した類型）ため、別 PR で対応するのが安全と判断しました。

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)
