### PR TITLE
fix: events の書き込みポリシーに所属チームの検査を足す (#116)

### DIFF
--- a/supabase/migrations/0023_fix_events_write_policies.sql
+++ b/supabase/migrations/0023_fix_events_write_policies.sql
@@ -1,0 +1,77 @@
+-- ============================================================
+-- 0023_fix_events_write_policies.sql
+-- events の書き込みポリシーに所属チームの検査を足す（#116 / セキュリティ）
+--
+-- 症状:
+--   events の書き込み側 RLS は 0001 のまま一度も見直されておらず、
+--   **所属していないチームに予定を挿入・移動できる**。
+--
+--     CREATE POLICY "events_insert" ON events
+--       FOR INSERT WITH CHECK ("createdBy" = auth.uid());
+--
+--     CREATE POLICY "events_update" ON events
+--       FOR UPDATE USING ("createdBy" = auth.uid());
+--
+--   穴は2つ:
+--
+--   ① events_insert が "teamId" を検査していない
+--      createdBy が自分であることしか見ていないため、teamId に任意の
+--      チームの uuid を入れて挿入できる。挿入された予定はそのチームの
+--      全メンバーのカレンダーに表示される。
+--
+--   ② events_update に WITH CHECK が無い
+--      PostgreSQL では USING は「どの行を更新してよいか」を決めるだけで、
+--      **更新後の行の内容は制約しない**。そのため自分のチームで予定を
+--      作ってから teamId を任意のチームへ書き換えられる。①のように
+--      相手チームの uuid を事前に知らなくても、一度作って移動すれば同じ。
+--
+--   読み取り側の同種の問題（#107）は 0021 で修正済み。本ファイルはその
+--   書き込み側にあたる。
+--
+-- 安全性:
+--   デプロイ済みのフロントは events への書き込みを3箇所しか持たない
+--   （CalendarTab のみ。grep で確認済み）:
+--
+--     insert: { ...values, createdBy: user.id, teamId: teams[0].id }
+--             teams は自分の所属チーム一覧なので所属は必ず成立する
+--     update: update(values).eq('id', editingId)
+--             values に teamId は含まれないので、更新でチームは移動しない
+--     delete: delete().eq('id', id)  … 本ファイルでは触らない
+--
+--   よってこの厳格化で現行コードは壊れない。
+--
+--   ポリシー式から参照する user_teams は "userId" = auth.uid()
+--   すなわち**自分の行**しか読まないため、0019 の回帰2（他人の行が
+--   RLS で見えず EXISTS が成立しない）は起きない。
+--
+-- 既知の挙動変化:
+--   チームを退出したあと、そのチームに残した自分の予定を**編集**できなく
+--   なる（WITH CHECK が通らないため）。閲覧と削除は createdBy だけを見る
+--   ので従来どおり可能。退出したチームの予定を書き換えられない方が
+--   望ましいと判断してこの形にした。
+-- ============================================================
+
+DROP POLICY IF EXISTS "events_insert" ON events;
+
+CREATE POLICY "events_insert" ON events
+  FOR INSERT WITH CHECK (
+    "createdBy" = auth.uid()
+    AND "teamId" IN (
+      SELECT "teamId" FROM user_teams WHERE "userId" = auth.uid()
+    )
+  );
+
+DROP POLICY IF EXISTS "events_update" ON events;
+
+CREATE POLICY "events_update" ON events
+  FOR UPDATE
+  -- どの行を更新できるか（更新前の行に対する判定）
+  USING ("createdBy" = auth.uid())
+  -- 更新後の行が満たすべき条件。これが無いと teamId を任意の
+  -- チームへ書き換えられる。
+  WITH CHECK (
+    "createdBy" = auth.uid()
+    AND "teamId" IN (
+      SELECT "teamId" FROM user_teams WHERE "userId" = auth.uid()
+    )
+  );


### PR DESCRIPTION
## 概要

`events` の書き込み側 RLS が所属チームを検査しておらず、**所属していないチームに予定を挿入・移動できる**問題を修正します。(#116)

`supabase/migrations/0023_fix_events_write_policies.sql` の1ファイルのみの追加です。読み取り側の同種の問題（#107）は #115 で修正済みで、本 PR はその**書き込み側**にあたります。

## 穴は2つ

**① `events_insert` が `teamId` を検査していない**

```sql
CREATE POLICY "events_insert" ON events
  FOR INSERT WITH CHECK ("createdBy" = auth.uid());
```

`createdBy` が自分であることしか見ていないため、`teamId` に任意のチームの uuid を入れて挿入できます。挿入された予定は**そのチームの全メンバーのカレンダーに表示されます**。

**② `events_update` に `WITH CHECK` が無い**

```sql
CREATE POLICY "events_update" ON events
  FOR UPDATE USING ("createdBy" = auth.uid());
```

PostgreSQL では `USING` は「どの行を更新してよいか」を決めるだけで、**更新後の行の内容は制約しません**。そのため自分のチームで予定を作ってから `teamId` を任意のチームへ書き換えられます。①のように相手チームの uuid を事前に知らなくても、一度作って移動すれば同じことができます。

## 安全性（現行コードが壊れないことの確認）

runbook の「影響範囲は機械的に洗う」に従い、`events` への書き込みを grep で全列挙しました。**`CalendarTab` の3箇所のみ**です。

| 箇所 | 内容 | 新ポリシー下での可否 |
|---|---|---|
| [CalendarTab.tsx:296](src/components/Calendar/CalendarTab.tsx:296) | `insert({ ...values, createdBy: user.id, teamId: teams[0].id })` | ✅ `teams` は自分の所属チーム一覧なので所属は必ず成立 |
| [CalendarTab.tsx:295](src/components/Calendar/CalendarTab.tsx:295) | `update(values).eq('id', editingId)` | ✅ `values` に `teamId` は含まれず、更新でチームは移動しない |
| [CalendarTab.tsx:316](src/components/Calendar/CalendarTab.tsx:316) | `delete().eq('id', id)` | ✅ 本 PR では触らない |

ポリシー式から参照する `user_teams` は `"userId" = auth.uid()` すなわち**自分の行**しか読まないため、`0019` の回帰2（他人の行が RLS で見えず EXISTS が成立しない）は起きません。

## 既知の挙動変化

チームを**退出したあと**、そのチームに残した自分の予定を**編集できなくなります**（`WITH CHECK` が通らないため）。閲覧と削除は `createdBy` だけを見るので従来どおり可能です。

退出したチームの予定を書き換えられない方が望ましいと判断してこの形にしましたが、気になるようなら `USING` 側と揃える形に変更できます。

## 検証状況

- [x] `npm run lint` が通る
- [x] `npm run build` が通る
- [x] `npm test` が通る（80件）
- [x] events への書き込み経路を grep で全列挙し、壊れないことを確認
- [ ] SQL の実行検証 ← **未実施**。Docker も psql も無くローカル Supabase を起動できないためデスクチェックのみです

## マージ順について

`supabase/migrations/` に新規1ファイルを足すだけなので、**PR #114（フロントエンド）/ #115（`0021`）/ #118（`0022`）のいずれとも競合しません。** 番号は `0023` で、全ブランチを確認して重複が無いことを確認済みです。

⚠️ **書き込みの厳格化は 2026-08-11 に本番を壊した類型**です。[runbook](docs/migration-deploy-runbook.md) の鉄則どおり、本番への `db push` はこの PR がマージ・デプロイされた後に行ってください。

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)
