### PR TITLE
fix: タブを切り替えるとマップの共有範囲が private に戻る問題を修正 (#111)

### DIFF
--- a/src/components/Map/MapTab.tsx
+++ b/src/components/Map/MapTab.tsx
@@ -242,6 +242,40 @@ export default function MapTab() {
     void fetchFriends()
   }, [fetchFriends])
 
+  // 自分の共有設定を DB から復元する（#111）。
+  //
+  // MainLayout の <Tabs isLazy> は既定が lazyBehavior="unmount" なので、
+  // タブを離れると MapTab ごと unmount され、戻ると sharingState は
+  // リテラル初期値の 'private' で作り直される。locations は upsert して
+  // いるだけで一度も読んでいなかったため、DB に 'team' が入っていても
+  // 画面は 'private' を表示していた。
+  //
+  // 表示のずれだけでなく、ライブ共有が有効だとそのまま次の送信で
+  // 'private' を書き戻すため、ユーザーが何もしていないのに共有範囲が
+  // 黙って下がる（チームメイトから見えなくなる）。
+  //
+  // locations_select は自分の行を必ず返すので RLS 上も問題ない。
+  const restoreSharingSettings = useCallback(async () => {
+    if (!user) return
+    const { data, error } = await supabase
+      .from('locations')
+      .select('sharingState, sharedTeamIds')
+      .eq('userId', user.id)
+      .maybeSingle()
+    if (error) {
+      console.error('restore sharing settings error', error)
+      return
+    }
+    // 行が無い＝まだ一度も位置を送っていない。既定の 'private' のままでよい。
+    if (!data) return
+    setSharingState(data.sharingState)
+    setSharedTeams(new Set(data.sharedTeamIds ?? []))
+  }, [user])
+
+  useEffect(() => {
+    void restoreSharingSettings()
+  }, [restoreSharingSettings])
+
   useEffect(() => {
     if (!user) return
     if (!('geolocation' in navigator)) {


### PR DESCRIPTION
## 原因

`MapTab` は `locations` を **`upsert` しているだけで一度も読んでいませんでした**。`from('locations')` の登場箇所は [MapTab.tsx](src/components/Map/MapTab.tsx) 内に1つ（書き込み）だけです。

そのため `sharingState` / `sharedTeams` はリテラル初期値（`'private'` / 空 `Set`）のままです。

```tsx
const [sharingState, setSharingState] = useState<LocationRow['sharingState']>('private')
const [sharedTeams, setSharedTeams] = useState<Set<string>>(new Set())
```

ここに `MainLayout` の `<Tabs isLazy>` が噛みます。**`isLazy` の既定は `lazyBehavior="unmount"`** なので、タブを離れると `MapTab` ごと unmount され、戻ると `'private'` で作り直されます。DB は変わっていないため表示だけがずれる、という報告どおりの症状です。

## 起票時より症状が重いです

**誤表示だけでは済みません。ライブ共有が有効だと、DB が `'private'` に上書きされます。**

remount 後の自動送信（[MapTab.tsx:324](src/components/Map/MapTab.tsx:324)）も、ライブ共有をオンにした直後の即時送信（同331行）も、どちらも state の `sharingState` をそのまま `upsertLocation` に渡しています。remount 直後はそれが `'private'` です。

結果、**ユーザーが何も操作していないのに共有範囲が実際に下がり、チームメイトから見えなくなります。** 本人はそれに気づけません。共有が減る方向なので安全側ではありますが、設定した意図が黙って壊れます。

## 修正

マウント時に自分の `locations` 行を読み、`sharingState` と `sharedTeamIds` の両方を復元します。行が無い（まだ一度も位置を送っていない）場合は既定の `'private'` のままにします。

`locations_select` は自分の行を必ず返すので RLS 上の問題はありません。

### `lazyBehavior="keepMounted"` にしなかった理由

remount は防げますが、**ページを開き直した直後は結局 `'private'` 表示のまま**で DB と食い違います。unmount するかどうかに関係なく、DB を読まない限り正しくなりません。

## PR #114 との関係

`MapTab.tsx` は PR #114 も触っていますが、**両者は別ハンクなので衝突しません**。#114 の変更は import 行と 370 行以降の JSX（余白・文字サイズ・地図の高さ・コントロール位置）で、本 PR は state 復元のロジックです。

実際に試験マージして確認済みです。

```
git merge --no-commit --no-ff origin/claude/daily-share-responsive-wdot1b
→ 衝突なし（自動マージ成功）
```

どちらを先にマージしても問題ありません。

## 検証状況

- [x] `npm run lint` が通る
- [x] `npm run build` が通る
- [x] `npm test` が通る（80件）
- [x] PR #114 との試験マージで衝突が無いことを確認
- [ ] 動作確認 ← **未実施**。ログインが必要なため

動作確認は、**共有範囲を `team` にする → 別タブへ移動 → マップへ戻る**で `team` のままなら OK です。修正前は `private` に戻ります。

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)
