### PR TITLE
feat: 未読メッセージ件数をチャットタブとルーム一覧にバッジ表示する (#110)

### DIFF
--- a/src/components/Chat/ChatTab.tsx
+++ b/src/components/Chat/ChatTab.tsx
@@ -5,7 +5,14 @@ import { Card } from '../ui/Card'
 import { RoomList } from './RoomList'
 import { RoomView } from './RoomView'
 
-export default function ChatTab() {
+interface ChatTabProps {
+  /** teamId -> 未読件数。MainLayout 側で数えたものを受け取る（#110）。 */
+  unreadByTeam?: Map<string, number>
+  /** ルームを開いたときに既読位置を進める。 */
+  onOpenRoom?: (teamId: string) => void
+}
+
+export default function ChatTab({ unreadByTeam, onOpenRoom }: ChatTabProps = {}) {
   const { user, teams, refreshProfile } = useAuth()
   // 退出などで所属から外れた ID が残っても、描画時に teams.find で
   // フォールバックするため一覧へ自然に戻る（同期用の effect は不要）。
@@ -47,7 +54,15 @@ export default function ChatTab() {
           トークルームを選ぶと、チームのメンバーとリアルタイムにやり取りできます。
         </Text>
       </Box>
-      <RoomList teams={teams} onSelect={setSelectedTeamId} />
+      <RoomList
+        teams={teams}
+        unreadByTeam={unreadByTeam}
+        onSelect={(teamId) => {
+          // 開いた時点で既読にする。数える側は MainLayout なので通知する。
+          onOpenRoom?.(teamId)
+          setSelectedTeamId(teamId)
+        }}
+      />
     </VStack>
   )
 }

--- a/src/components/Chat/RoomList.tsx
+++ b/src/components/Chat/RoomList.tsx
@@ -3,6 +3,7 @@ import { Box, Flex, HStack, Text, Avatar, VStack } from '@chakra-ui/react'
 import { avatarColor } from '../../lib/avatarColor'
 import { supabase } from '../../lib/supabase'
 import type { Database } from '../../types/database'
+import { formatBadgeCount } from './unreadUtils'
 import {
   foldLatestByTeam,
   formatListTime,
@@ -31,9 +32,11 @@ const PREVIEW_FETCH_LIMIT = 200
 interface RoomListProps {
   teams: Team[]
   onSelect: (teamId: string) => void
+  /** teamId -> 未読件数（#110）。MainLayout 側で数えたものを受け取る。 */
+  unreadByTeam?: Map<string, number>
 }
 
-export function RoomList({ teams, onSelect }: RoomListProps) {
+export function RoomList({ teams, onSelect, unreadByTeam }: RoomListProps) {
   // teamId -> 最新メッセージ。
   const [previews, setPreviews] = useState<Map<string, Preview>>(new Map())
 
@@ -107,6 +110,7 @@ export function RoomList({ teams, onSelect }: RoomListProps) {
     >
       {orderedTeams.map((t, i) => {
         const preview = previews.get(t.id)
+        const unread = unreadByTeam?.get(t.id) ?? 0
         return (
           <HStack
             key={t.id}
@@ -129,9 +133,34 @@ export function RoomList({ teams, onSelect }: RoomListProps) {
                   {formatListTime(preview?.createdAt ?? null)}
                 </Text>
               </Flex>
-              <Text fontSize="sm" color="gray.500" noOfLines={1}>
-                {preview ? preview.body : 'まだメッセージがありません'}
-              </Text>
+              <Flex justify="space-between" align="center" gap={2}>
+                <Text
+                  fontSize="sm"
+                  color={unread > 0 ? 'gray.800' : 'gray.500'}
+                  fontWeight={unread > 0 ? 'semibold' : undefined}
+                  noOfLines={1}
+                >
+                  {preview ? preview.body : 'まだメッセージがありません'}
+                </Text>
+                {unread > 0 && (
+                  <Box
+                    as="span"
+                    flexShrink={0}
+                    minW="20px"
+                    px="6px"
+                    bg="danger.500"
+                    color="white"
+                    borderRadius="full"
+                    fontSize="xs"
+                    lineHeight="20px"
+                    fontWeight="bold"
+                    textAlign="center"
+                    aria-label={`未読 ${unread} 件`}
+                  >
+                    {formatBadgeCount(unread)}
+                  </Box>
+                )}
+              </Flex>
             </Box>
           </HStack>
         )

--- a/src/components/Chat/unreadUtils.test.ts
+++ b/src/components/Chat/unreadUtils.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest'
+import { countUnreadByTeam, formatBadgeCount, totalUnread } from './unreadUtils'
+
+const ME = 'me'
+const msg = (teamId: string, userId: string, createdAt: string | null) => ({
+  teamId,
+  userId,
+  createdAt,
+})
+
+describe('countUnreadByTeam', () => {
+  it('lastReadAt より新しい他人の投稿だけ数える', () => {
+    const counts = countUnreadByTeam(
+      [
+        msg('t1', 'other', '2026-08-25T10:00:00Z'),
+        msg('t1', 'other', '2026-08-25T09:00:00Z'), // 既読より古い
+      ],
+      new Map([['t1', '2026-08-25T09:30:00Z']]),
+      ME,
+    )
+    expect(counts.get('t1')).toBe(1)
+  })
+
+  it('自分の投稿は数えない', () => {
+    const counts = countUnreadByTeam(
+      [msg('t1', ME, '2026-08-25T10:00:00Z'), msg('t1', 'other', '2026-08-25T10:00:00Z')],
+      new Map(),
+      ME,
+    )
+    expect(counts.get('t1')).toBe(1)
+  })
+
+  it('lastReadAt が無いチームは全件を未読にする', () => {
+    const counts = countUnreadByTeam(
+      [msg('t1', 'other', '2026-08-25T10:00:00Z'), msg('t1', 'other', '2026-01-01T00:00:00Z')],
+      new Map(),
+      ME,
+    )
+    expect(counts.get('t1')).toBe(2)
+  })
+
+  it('既読と同時刻は未読にしない（境界）', () => {
+    const at = '2026-08-25T10:00:00Z'
+    const counts = countUnreadByTeam([msg('t1', 'other', at)], new Map([['t1', at]]), ME)
+    expect(counts.has('t1')).toBe(false)
+  })
+
+  it('createdAt が null の行は数えない', () => {
+    const counts = countUnreadByTeam([msg('t1', 'other', null)], new Map(), ME)
+    expect(counts.has('t1')).toBe(false)
+  })
+
+  it('チームごとに独立して数える', () => {
+    const counts = countUnreadByTeam(
+      [
+        msg('t1', 'other', '2026-08-25T10:00:00Z'),
+        msg('t2', 'other', '2026-08-25T10:00:00Z'),
+        msg('t2', 'other', '2026-08-25T11:00:00Z'),
+      ],
+      new Map([['t1', '2026-08-25T09:00:00Z']]),
+      ME,
+    )
+    expect(counts.get('t1')).toBe(1)
+    expect(counts.get('t2')).toBe(2)
+  })
+
+  it('未読 0 のチームはキーを持たない', () => {
+    const counts = countUnreadByTeam(
+      [msg('t1', 'other', '2026-08-25T08:00:00Z')],
+      new Map([['t1', '2026-08-25T09:00:00Z']]),
+      ME,
+    )
+    expect(counts.has('t1')).toBe(false)
+    expect(totalUnread(counts)).toBe(0)
+  })
+
+  it('currentUserId が未確定でも落ちない', () => {
+    const counts = countUnreadByTeam([msg('t1', 'other', '2026-08-25T10:00:00Z')], new Map(), undefined)
+    expect(counts.get('t1')).toBe(1)
+  })
+})
+
+describe('totalUnread', () => {
+  it('全チームの合計を返す', () => {
+    expect(totalUnread(new Map([['t1', 2], ['t2', 3]]))).toBe(5)
+  })
+})
+
+describe('formatBadgeCount', () => {
+  it('9 以下はそのまま、10 以上は 9+', () => {
+    expect(formatBadgeCount(1)).toBe('1')
+    expect(formatBadgeCount(9)).toBe('9')
+    expect(formatBadgeCount(10)).toBe('9+')
+  })
+})

--- a/src/components/Chat/unreadUtils.ts
+++ b/src/components/Chat/unreadUtils.ts
@@ -1,0 +1,50 @@
+/**
+ * 未読件数の集計（#110）。
+ *
+ * 画面から切り離してテストできるよう、純粋な関数としてここに置く
+ * （roomListUtils と同じ方針）。
+ */
+
+export interface UnreadMessageLike {
+  teamId: string
+  userId: string
+  createdAt: string | null
+}
+
+/**
+ * teamId ごとの未読件数を数える。
+ *
+ * - 自分の投稿は数えない（送った本人にとって未読ではないため）
+ * - `lastReadAt` が無いチームは「一度も開いていない」とみなし全件を未読とする
+ * - `createdAt` が null の行は順序が決められないので数えない
+ *
+ * 0 件のチームはキーを持たない（呼び出し側は has/get の既定 0 で扱える）。
+ */
+export function countUnreadByTeam(
+  messages: UnreadMessageLike[],
+  lastReadByTeam: Map<string, string>,
+  currentUserId: string | undefined,
+): Map<string, number> {
+  const counts = new Map<string, number>()
+  for (const m of messages) {
+    if (!m.createdAt) continue
+    if (currentUserId && m.userId === currentUserId) continue
+    const lastRead = lastReadByTeam.get(m.teamId)
+    // lastRead が無ければ全件が未読。あれば厳密に新しいものだけ。
+    if (lastRead && Date.parse(m.createdAt) <= Date.parse(lastRead)) continue
+    counts.set(m.teamId, (counts.get(m.teamId) ?? 0) + 1)
+  }
+  return counts
+}
+
+/** バッジに出す合計。 */
+export function totalUnread(counts: Map<string, number>): number {
+  let total = 0
+  for (const n of counts.values()) total += n
+  return total
+}
+
+/** 9 件を超えたら "9+" にする（NotificationBell と同じ見せ方）。 */
+export function formatBadgeCount(n: number): string {
+  return n > 9 ? '9+' : String(n)
+}

--- a/src/components/Layout/MainLayout.tsx
+++ b/src/components/Layout/MainLayout.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useCallback, useState } from 'react'
+import { lazy, Suspense, useCallback, useMemo, useState } from 'react'
 import {
   Box,
   Flex,
@@ -23,6 +23,8 @@ import {
 } from '@chakra-ui/react'
 import { avatarColor } from '../../lib/avatarColor'
 import { useAuth } from '../../hooks/useAuth'
+import { useUnreadMessages } from '../../hooks/useUnreadMessages'
+import { formatBadgeCount } from '../Chat/unreadUtils'
 import { useRedeemPendingInvite } from '../../hooks/usePendingInvite'
 import { Wordmark } from '../ui/Wordmark'
 import { AccountModal } from '../Account/AccountModal'
@@ -40,6 +42,15 @@ const TeamsTab = lazy(() => import('../Team/TeamsTab'))
 /** タブの並び順（カレンダー・地図・トーク・フレンド・チーム）における「トーク」。 */
 const TALK_TAB_INDEX = 2
 
+/** ヘッダーのタブ定義。badge を持つタブにだけ未読バッジを出す。 */
+const TABS: { icon: string; label: string; badge?: boolean }[] = [
+  { icon: '🗓', label: 'カレンダー' },
+  { icon: '🗺', label: 'マップ' },
+  { icon: '💬', label: 'チャット', badge: true },
+  { icon: '🤝', label: 'フレンド' },
+  { icon: '👥', label: 'チーム' },
+]
+
 function TabFallback() {
   return (
     <Center py={20}>
@@ -49,7 +60,11 @@ function TabFallback() {
 }
 
 export function MainLayout() {
-  const { user, profile, signOut, refreshProfile } = useAuth()
+  const { user, profile, teams, signOut, refreshProfile } = useAuth()
+  // 未読件数は MainLayout 側で数える。<Tabs isLazy> はタブを離れると
+  // ChatTab を unmount するため、ChatTab の中では数え続けられない。
+  const teamIds = useMemo(() => teams.map((t) => t.id), [teams])
+  const { unreadByTeam, unreadTotal, markTeamRead } = useUnreadMessages(user?.id, teamIds)
   const [tabIndex, setTabIndex] = useState(0)
   const name = profile?.displayName ?? 'ゲスト'
   const email = profile?.email ?? user?.email ?? ''
@@ -91,13 +106,7 @@ export function MainLayout() {
               <Wordmark size="sm" />
 
               <TabList gap={1} bg="gray.100" p={1} borderRadius="full">
-                {[
-                  { icon: '🗓', label: 'カレンダー' },
-                  { icon: '🗺', label: 'マップ' },
-                  { icon: '💬', label: 'チャット' },
-                  { icon: '🤝', label: 'フレンド' },
-                  { icon: '👥', label: 'チーム' },
-                ].map((t) => (
+                {TABS.map((t) => (
                   <Tab
                     key={t.label}
                     borderRadius="full"
@@ -111,7 +120,30 @@ export function MainLayout() {
                     _hover={{ color: 'gray.700' }}
                   >
                     <HStack spacing={1.5}>
-                      <Box as="span">{t.icon}</Box>
+                      {/* 未読バッジはアイコンの右肩に重ねるので relative が要る */}
+                      <Box as="span" position="relative">
+                        {t.icon}
+                        {t.badge && unreadTotal > 0 && (
+                          <Box
+                            as="span"
+                            position="absolute"
+                            top="-6px"
+                            right="-8px"
+                            minW="16px"
+                            px="4px"
+                            bg="danger.500"
+                            color="white"
+                            borderRadius="full"
+                            fontSize="10px"
+                            lineHeight="16px"
+                            fontWeight="bold"
+                            textAlign="center"
+                            aria-label={`未読 ${unreadTotal} 件`}
+                          >
+                            {formatBadgeCount(unreadTotal)}
+                          </Box>
+                        )}
+                      </Box>
                       <Box as="span" display={{ base: 'none', sm: 'block' }}>
                         {t.label}
                       </Box>
@@ -181,7 +213,7 @@ export function MainLayout() {
             </TabPanel>
             <TabPanel p={0}>
               <Suspense fallback={<TabFallback />}>
-                <ChatTab />
+                <ChatTab unreadByTeam={unreadByTeam} onOpenRoom={markTeamRead} />
               </Suspense>
             </TabPanel>
             <TabPanel p={0}>

--- a/src/hooks/useUnreadMessages.ts
+++ b/src/hooks/useUnreadMessages.ts
@@ -1,0 +1,124 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { supabase } from '../lib/supabase'
+import {
+  countUnreadByTeam,
+  totalUnread,
+  type UnreadMessageLike,
+} from '../components/Chat/unreadUtils'
+
+/**
+ * 未読メッセージ件数（#110）。
+ *
+ * **MainLayout 側に置くこと。** <Tabs isLazy> はタブを離れると ChatTab を
+ * unmount するため、ChatTab の中で数えるとチャットタブを開いている間しか
+ * 数えられず、バッジの意味が無くなる。
+ *
+ * 取得は RoomList と同じ「まとめて取ってクライアントで畳む」方式。
+ * チームごとに件数を問い合わせると所属チーム数だけ往復が発生するため、
+ * 新しい順にまとめて取得して teamId ごとに数える。team_messages は
+ * 30 日で自動削除される（0004）ので総量は小さい。
+ */
+const FETCH_LIMIT = 300
+const POLL_MS = 30_000
+
+export function useUnreadMessages(userId: string | undefined, teamIds: string[]) {
+  const [counts, setCounts] = useState<Map<string, number>>(new Map())
+
+  // teams は毎レンダー新しい配列になりうるので、依存には安定なキーを使う。
+  const teamIdsKey = useMemo(() => teamIds.join(','), [teamIds])
+  // Realtime のハンドラから最新の refresh を呼ぶための箱。
+  const refreshRef = useRef<() => void>(() => {})
+
+  const refresh = useCallback(async () => {
+    const ids = teamIdsKey ? teamIdsKey.split(',') : []
+    if (!userId || ids.length === 0) {
+      setCounts(new Map())
+      return
+    }
+
+    const [readsRes, msgsRes] = await Promise.all([
+      supabase.from('message_reads').select('teamId, lastReadAt').eq('userId', userId),
+      supabase
+        .from('team_messages')
+        .select('teamId, userId, createdAt')
+        .in('teamId', ids)
+        .order('createdAt', { ascending: false })
+        .limit(FETCH_LIMIT),
+    ])
+
+    if (readsRes.error || msgsRes.error) {
+      console.error('unread fetch error', readsRes.error ?? msgsRes.error)
+      return
+    }
+
+    const lastReadByTeam = new Map<string, string>()
+    for (const r of readsRes.data ?? []) {
+      if (r.lastReadAt) lastReadByTeam.set(r.teamId, r.lastReadAt)
+    }
+    setCounts(
+      countUnreadByTeam((msgsRes.data ?? []) as UnreadMessageLike[], lastReadByTeam, userId),
+    )
+  }, [userId, teamIdsKey])
+
+  useEffect(() => {
+    refreshRef.current = () => void refresh()
+  }, [refresh])
+
+  /** ルームを開いたときに既読位置を進める。 */
+  const markTeamRead = useCallback(
+    async (teamId: string) => {
+      if (!userId) return
+      // 先に画面から消す。往復を待たせるとバッジが残って見える。
+      setCounts((prev) => {
+        if (!prev.has(teamId)) return prev
+        const next = new Map(prev)
+        next.delete(teamId)
+        return next
+      })
+      const { error } = await supabase
+        .from('message_reads')
+        .upsert(
+          { userId, teamId, lastReadAt: new Date().toISOString() },
+          { onConflict: 'userId,teamId' },
+        )
+      if (error) {
+        console.error('mark read error', error)
+        // 保存できていないので数え直す（楽観更新を巻き戻す）。
+        void refresh()
+      }
+    },
+    [userId, refresh],
+  )
+
+  useEffect(() => {
+    // 初回取得も ref 経由で呼ぶ。エフェクト本体から直接 refresh() を呼ぶと
+    // 早期リターンの空クリアが同期 setState になり、cascading render を
+    // 招く（react-hooks/set-state-in-effect）。
+    refreshRef.current()
+    const id = setInterval(() => refreshRef.current(), POLL_MS)
+    const onFocus = () => refreshRef.current()
+    window.addEventListener('focus', onFocus)
+    return () => {
+      clearInterval(id)
+      window.removeEventListener('focus', onFocus)
+    }
+  }, [refresh])
+
+  // 新着を即座にバッジへ反映する。team_messages は Realtime 有効（0003）。
+  useEffect(() => {
+    if (!userId || !teamIdsKey) return
+    const channel = supabase
+      .channel('unread:team_messages')
+      .on(
+        'postgres_changes',
+        { event: 'INSERT', schema: 'public', table: 'team_messages' },
+        () => refreshRef.current(),
+      )
+      .subscribe()
+    return () => {
+      void supabase.removeChannel(channel)
+    }
+  }, [userId, teamIdsKey])
+
+  return { unreadByTeam: counts, unreadTotal: totalUnread(counts), markTeamRead, refresh }
+}

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -237,6 +237,24 @@ export type Database = {
         }
         Relationships: []
       }
+      message_reads: {
+        Row: {
+          userId: string
+          teamId: string
+          lastReadAt: string
+        }
+        Insert: {
+          userId: string
+          teamId: string
+          lastReadAt?: string
+        }
+        Update: {
+          userId?: string
+          teamId?: string
+          lastReadAt?: string
+        }
+        Relationships: []
+      }
       locations: {
         Row: {
           userId: string

--- a/supabase/migrations/0025_message_reads.sql
+++ b/supabase/migrations/0025_message_reads.sql
@@ -1,0 +1,75 @@
+-- ============================================================
+-- 0025_message_reads.sql
+-- トークの既読位置を保存する（#110 未読バッジ）
+--
+-- 背景:
+--   team_messages（0003）は id / teamId / userId / body / createdAt だけで、
+--   既読を表す列もテーブルも無かった。未読件数を出すには保存先が要る。
+--
+-- なぜ user_teams に "lastReadAt" を足さないのか（重要）:
+--   issue #110 は最小構成として user_teams への列追加を挙げているが、
+--   **この案は権限昇格の穴になる。**
+--
+--   user_teams には UPDATE ポリシーが存在しない（0001 / 0017 とも
+--   select / insert / delete のみ）。既読を更新するには UPDATE を許す
+--   必要があるが、素直に
+--
+--       CREATE POLICY ... FOR UPDATE USING ("userId" = auth.uid())
+--
+--   と書くと、同じ行の role 列も更新できてしまう:
+--
+--       UPDATE user_teams SET role = 'admin' WHERE "userId" = auth.uid();
+--
+--   RLS の WITH CHECK は**更新後の行しか見えない**ため、「role は据え置き」
+--   を式で強制できない。防ぐにはトリガーが要る。チーム権限の中核テーブル
+--   （CLAUDE.md「Team membership rules」）にその複雑さを持ち込むのは
+--   割に合わない。
+--
+--   既読はチーム権限と何の関係も無い情報なので、独立したテーブルへ隔離する。
+--   この表が持つのはタイムスタンプだけで、漏れても昇格に使えない。
+--
+-- 設計:
+--   ("userId","teamId") を複合主キーにして 1 チーム 1 行。
+--   upsert（onConflict: 'userId,teamId'）で既読位置を進める。
+--   未読件数は team_messages を "lastReadAt" より新しいものに絞って
+--   数える。行が無いチームは「一度も開いていない」として全件が未読。
+--   team_messages は 30 日で自動削除される（0004）ので上限は自然に付く。
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS message_reads (
+  "userId"     uuid        NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  "teamId"     uuid        NOT NULL REFERENCES teams(id) ON DELETE CASCADE,
+  "lastReadAt" timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY ("userId", "teamId")
+);
+
+ALTER TABLE message_reads ENABLE ROW LEVEL SECURITY;
+
+-- 自分の既読位置しか読めない。他人がどこまで読んだかは見せない。
+CREATE POLICY "message_reads_select" ON message_reads
+  FOR SELECT USING ("userId" = auth.uid());
+
+-- 自分の行だけ、かつ所属しているチームについてのみ作れる。
+-- user_teams は "userId" = auth.uid() すなわち自分の行しか読まないため、
+-- user_teams_select を通る（0019 の回帰2は起きない）。
+CREATE POLICY "message_reads_insert" ON message_reads
+  FOR INSERT WITH CHECK (
+    "userId" = auth.uid()
+    AND "teamId" IN (
+      SELECT "teamId" FROM user_teams WHERE "userId" = auth.uid()
+    )
+  );
+
+-- 更新も同条件。WITH CHECK を書いて "userId" の付け替えを塞ぐ。
+CREATE POLICY "message_reads_update" ON message_reads
+  FOR UPDATE
+  USING ("userId" = auth.uid())
+  WITH CHECK (
+    "userId" = auth.uid()
+    AND "teamId" IN (
+      SELECT "teamId" FROM user_teams WHERE "userId" = auth.uid()
+    )
+  );
+
+CREATE POLICY "message_reads_delete" ON message_reads
+  FOR DELETE USING ("userId" = auth.uid());


### PR DESCRIPTION
## 概要

チャットタブのアイコン右肩と、トークルーム一覧の各行に未読件数を赤いバッジで表示します。(#110)

既読状態の保存先が存在しなかったため、マイグレーション（`0025_message_reads.sql`）を追加しています。

## ⚠️ issue の「最小構成」は採用していません（権限昇格の穴のため）

issue は最小構成として **`user_teams` に `lastReadAt` を足す**案を挙げていますが、**この案は権限昇格につながります。**

`user_teams` には UPDATE ポリシーが存在しません（`0001` / `0017` とも select / insert / delete のみ）。既読を更新するには UPDATE を許す必要がありますが、素直に書くと:

```sql
CREATE POLICY ... FOR UPDATE USING ("userId" = auth.uid());
```

同じ行の **`role` 列も更新できてしまいます**。

```sql
UPDATE user_teams SET role = 'admin' WHERE "userId" = auth.uid();  -- 誰でも管理者になれる
```

RLS の `WITH CHECK` は**更新後の行しか参照できない**ため、「`role` は据え置き」を式で強制できません。防ぐにはトリガーが必要です。チーム権限の中核テーブル（CLAUDE.md「Team membership rules」）にその複雑さを持ち込むのは割に合わないと判断しました。

**既読はチーム権限と無関係な情報なので、独立した `message_reads` テーブルへ隔離しています。** この表が持つのはタイムスタンプだけで、漏れても昇格には使えません。

## 設計

| | |
|---|---|
| テーブル | `("userId","teamId")` の複合主キーで1チーム1行。`upsert(onConflict: 'userId,teamId')` で既読位置を進める |
| RLS | 自分の行のみ、かつ**所属しているチームのみ**。参照する `user_teams` は自分の行しか読まないので `0019` の回帰2は起きない |
| フックの置き場所 | **`MainLayout` 側**。`<Tabs isLazy>` はタブを離れると `ChatTab` を unmount するため、`ChatTab` の中では数え続けられない（issue の指摘どおり） |
| 取得方法 | `RoomList` と同じ「まとめて取ってクライアントで畳む」方式。チームごとに問い合わせると所属数だけ往復が出るため。`team_messages` は30日で自動削除される（`0004`、cron 稼働を #106 で実証済み）ので総量は小さい |
| 更新 | Realtime の INSERT 購読で新着を即反映。加えて30秒ポーリングと focus 時再取得（`useNotifications` と同じ形） |
| 仕様 | 自分の投稿は数えない。ルームを開いた時点で既読にする。10件以上は `9+` 表示（`NotificationBell` と揃えた） |

集計は `unreadUtils.ts` に純粋関数として切り出し、テストを10件追加しました（`roomListUtils` と同じ方針）。境界（既読と同時刻）、`createdAt` が null、未読0のチーム、自分の投稿の除外などを網羅しています。

## 検証状況

- [x] `npm run lint` が通る
- [x] `npm run build` が通る
- [x] `npm test` が通る（**130件**。うち10件が今回追加）
- [x] dev サーバ起動時にコンソールエラーが無いことを確認
- [ ] **バッジの実表示は未確認** ← ログインが必要なため

動作確認は、**別アカウントからメッセージを送る → チャットタブのアイコンに赤バッジが出る → ルームを開くとバッジが消える**という流れでお願いします。ルーム一覧の各行にも件数が出ます。

## マージ後の注意

1. `0025` の適用は runbook どおり**マージ・デプロイ後**に `db push` してください
2. **適用後に型を作り直してください。** `message_reads` は本番未適用のため型生成ができず、`src/types/database.ts` に手で足しています

```bash
npx supabase gen types --lang=typescript --project-id mdetcjwmwzjeupheppgo > src/types/database.ts
```

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)
